### PR TITLE
feat: return all source locations in normalize response (#126)

### DIFF
--- a/gene/etl/merge.py
+++ b/gene/etl/merge.py
@@ -144,8 +144,9 @@ class Merge:
                 if field not in merged_attrs and field in record:
                     merged_attrs[field] = record[field]
 
-            merged_attrs[f"{record['src_name'].lower()}_locations"] = \
-                record["locations"]
+            locations = record.get("locations")
+            if locations:
+                merged_attrs[f"{record['src_name'].lower()}_locations"] = locations
 
             gene_type = record.get("gene_type")
             if gene_type:

--- a/gene/etl/merge.py
+++ b/gene/etl/merge.py
@@ -135,7 +135,7 @@ class Merge:
         # merge from constituent records
         set_fields = ["aliases", "associated_with", "previous_symbols"]
         scalar_fields = ["symbol", "symbol_status", "label", "strand",
-                         "location_annotations", "locations"]
+                         "location_annotations"]
         for record in records:
             for field in set_fields:
                 merged_attrs[field] |= set(record.get(field, set()))
@@ -143,6 +143,9 @@ class Merge:
             for field in scalar_fields:
                 if field not in merged_attrs and field in record:
                     merged_attrs[field] = record[field]
+
+            merged_attrs[f"{record['src_name'].lower()}_locations"] = \
+                record["locations"]
 
             gene_type = record.get("gene_type")
             if gene_type:

--- a/gene/query.py
+++ b/gene/query.py
@@ -407,6 +407,7 @@ class QueryHandler:
             ("approved_name", "label"),
             ("associated_with", "associated_with"),
             ("previous_symbols", "previous_symbols"),
+            ("location_annotations", "location_annotations")
         ]
         for ext_label, record_label in extension_and_record_labels:
             if record_label in record and record[record_label]:
@@ -416,9 +417,10 @@ class QueryHandler:
                 ))
 
         if record["item_type"] == "identity":
-            extensions.append(Extension(
-                name=f"{record['src_name'].lower()}_locations",
-                value=record["locations"]))
+            loc = record.get("locations")
+            if loc:
+                extensions.append(Extension(
+                    name=f"{record['src_name'].lower()}_locations", value=loc))
         elif record["item_type"] == "merger":
             for k, v in record.items():
                 if k.endswith("locations") and v:

--- a/gene/query.py
+++ b/gene/query.py
@@ -405,18 +405,25 @@ class QueryHandler:
         extension_and_record_labels = [
             ("symbol_status", "symbol_status"),
             ("approved_name", "label"),
-            ("chromosome_location", "locations"),
             ("associated_with", "associated_with"),
             ("previous_symbols", "previous_symbols"),
         ]
         for ext_label, record_label in extension_and_record_labels:
             if record_label in record and record[record_label]:
-                if ext_label == 'chromosome_location':
-                    record[record_label] = record[record_label][0]
                 extensions.append(Extension(
                     name=ext_label,
                     value=record[record_label]
                 ))
+
+        if record["item_type"] == "identity":
+            extensions.append(Extension(
+                name=f"{record['src_name'].lower()}_locations",
+                value=record["locations"]))
+        elif record["item_type"] == "merger":
+            for k, v in record.items():
+                if k.endswith("locations") and v:
+                    extensions.append(Extension(name=k, value=v))
+
         # handle gene types separately because they're wonky
         if record["item_type"] == "identity":
             gene_type = record.get("gene_type")

--- a/gene/version.py
+++ b/gene/version.py
@@ -1,2 +1,2 @@
 """Gene normalizer version"""
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/unit/data/etl_data/hgnc_20210810.json
+++ b/tests/unit/data/etl_data/hgnc_20210810.json
@@ -1172,7 +1172,32 @@
                 ],
                 "entrez_id": "109280162",
                 "location_sortable": "10q23.3 or 10q24.2"
-            }
+            },
+            {
+                "date_approved_reserved": "1986-01-01",
+                "symbol": "IFNR",
+                "locus_type": "unknown",
+                "location": "16",
+                "omim_id": [
+                  "147573"
+                ],
+                "_version_": 1741469995314970627,
+                "curator_notes": [
+                  "This gene has the locus type unknown because it has never been mapped to the human genome."
+                ],
+                "locus_group": "other",
+                "uuid": "6af5e088-63ac-4f7e-b1ce-3edb4fd551aa",
+                "location_sortable": "16",
+                "hgnc_id": "HGNC:5447",
+                "status": "Approved",
+                "date_modified": "2019-06-26",
+                "name": "interferon production regulator",
+                "pubmed_id": [
+                  1906174,
+                  1193239
+                ],
+                "entrez_id": "3466"
+              }
         ],
         "start": 0
     }

--- a/tests/unit/data/etl_data/ncbi_info_20210813.tsv
+++ b/tests/unit/data/etl_data/ncbi_info_20210813.tsv
@@ -23,3 +23,4 @@
 9606	7637	ZNF84	-	HPF2	MIM:618554|HGNC:HGNC:13159|Ensembl:ENSG00000198040	12	12q24.33|map from Rosati ref via FISH [AFS]	zinc finger protein 84	protein-coding	ZNF84	zinc finger protein 84	O	zinc finger protein 84|zinc finger protein HPF2	20210611	-
 9606	619538	OMS	-	COME/ROM	MIM:166760	10|19|3	10q26.3;19q13.42-q13.43;3p25.3	otitis media, susceptibility to	unknown	-	-	-	chronic/recurrent otitis media	20170408	-
 9606	653303	LOC653303	-	-	-	11	11q23.3	proprotein convertase subtilisin/kexin type 7 pseudogene	pseudo	-	-	-	-	20211123	-
+9606	3466	IFNR	-	IFNGM|IFNGM2	MIM:147573|HGNC:HGNC:5447	16	-	interferon production regulator	unknown	IFNR	interferon production regulator	O	-	20190324	-

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -83,15 +83,63 @@ def normalized_ache():
                 "type": "Extension"
             },
             {
-                "name": "chromosome_location",
-                "value": {
-                    "id": "ga4gh:CL.JSw-08GkF-7M-OQR-33MLLKQHSi7QJb5",
-                    "type": "ChromosomeLocation",
-                    "species_id": "taxonomy:9606",
-                    "chr": "7",
-                    "end": "q22.1",
-                    "start": "q22.1"
-                },
+                "name": "ncbi_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.JSw-08GkF-7M-OQR-33MLLKQHSi7QJb5",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "7",
+                        "end": "q22.1",
+                        "start": "q22.1"
+                    },
+                    {
+                        "id": "ga4gh:SL.UZ4q9hFsiwhOMyB4nDftMupd-i0OVu4w",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                        "start": {
+                            "type": "Number",
+                            "value": 100889993
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 100896994
+                        }
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "hgnc_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.JSw-08GkF-7M-OQR-33MLLKQHSi7QJb5",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "7",
+                        "start": "q22.1",
+                        "end": "q22.1"
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ensembl_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:SL.K5fLruGxiT-ls_GjUrNpNm3tV01hhlgQ",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                        "start": {
+                            "type": "Number",
+                            "value": 100889993
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 100896974
+                        }
+                    }
+                ],
                 "type": "Extension"
             },
             {
@@ -165,15 +213,63 @@ def normalized_braf():
                 "type": "Extension"
             },
             {
-                "name": "chromosome_location",
-                "value": {
-                    "id": "ga4gh:CL.ZZZYpOwuW1BLLJXc_Dm4eVZ5E0smVYCc",
-                    "type": "ChromosomeLocation",
-                    "species_id": "taxonomy:9606",
-                    "chr": "7",
-                    "end": "q34",
-                    "start": "q34",
-                },
+                "name": "hgnc_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.ZZZYpOwuW1BLLJXc_Dm4eVZ5E0smVYCc",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "7",
+                        "end": "q34",
+                        "start": "q34",
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ensembl_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:SL.MPDI-H-JK1AMOnLdvVO6zQjbAXmSnzQ4",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                        "start": {
+                            "type": "Number",
+                            "value": 140719326
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 140924929
+                        }
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ncbi_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.ZZZYpOwuW1BLLJXc_Dm4eVZ5E0smVYCc",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "7",
+                        "start": "q34",
+                        "end": "q34"
+                    },
+                    {
+                        "id": "ga4gh:SL.po-AExwyqkstDx3JWYn6plIlxn5eojv4",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                        "start": {
+                            "type": "Number",
+                            "value": 140713327
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 140924929
+                        }
+                    }
+                ],
                 "type": "Extension"
             },
             {
@@ -261,15 +357,63 @@ def normalized_abl1():
                 "type": "Extension"
             },
             {
-                "name": "chromosome_location",
-                "value": {
-                    "id": "ga4gh:CL.1vsxettosueUHyFIOoTPzwIFD1DodLuT",
-                    "type": "ChromosomeLocation",
-                    "species_id": "taxonomy:9606",
-                    "chr": "9",
-                    "end": "q34.12",
-                    "start": "q34.12"
-                },
+                "name": "hgnc_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.1vsxettosueUHyFIOoTPzwIFD1DodLuT",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "9",
+                        "end": "q34.12",
+                        "start": "q34.12"
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ncbi_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.1vsxettosueUHyFIOoTPzwIFD1DodLuT",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "9",
+                        "start": "q34.12",
+                        "end": "q34.12"
+                    },
+                    {
+                        "id": "ga4gh:SL.av1JXWUExZbLU2LXsFYTUa8LOzJ1Za3o",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+                        "start": {
+                            "type": "Number",
+                            "value": 130713042
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 130887675
+                        }
+                    }
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ensembl_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:SL.LOUW5_mnHh4yMBagkbwu1BpUN-r0N-2U",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+                        "start": {
+                            "type": "Number",
+                            "value": 130713015
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 130887675
+                        }
+                    }
+                ],
                 "type": "Extension"
             },
             {
@@ -339,16 +483,62 @@ def normalized_p150():
                 "type": "Extension"
             },
             {
-                "name": "chromosome_location",
-                "value": {
-                    "id": "ga4gh:CL.kPEG2TGUPOAsAYK6HY0ukprQ-DR_IuMZ",
-                    "type": "ChromosomeLocation",
-                    "species_id": "taxonomy:9606",
-                    "chr": "19",
-                    "end": "p13.3",
-                    "start": "p13.3"
-                },
+                "name": "hgnc_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.kPEG2TGUPOAsAYK6HY0ukprQ-DR_IuMZ",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "19",
+                        "end": "p13.3",
+                        "start": "p13.3"
+                    }
+                ],
                 "type": "Extension"
+            },
+            {
+                "name": "ensembl_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:SL.kL2Hr6VSSiPQyjE_pJ1Ta5viB-yuJchF",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+                        "start": {
+                            "type": "Number",
+                            "value": 4402639
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 4445018
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "ncbi_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.kPEG2TGUPOAsAYK6HY0ukprQ-DR_IuMZ",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "19",
+                        "start": "p13.3",
+                        "end": "p13.3"
+                    },
+                    {
+                        "id": "ga4gh:SL.LTvvCAh9DqsH8G0A_rNgPafqvPmWk0tn",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+                        "start": {
+                            "type": "Number",
+                            "value": 4402639
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 4450830
+                        }
+                    }
+                ]
             },
             {
                 "name": "ncbi_gene_type",
@@ -396,16 +586,30 @@ def normalized_loc_653303():
                 "value": "proprotein convertase subtilisin/kexin type 7 pseudogene"
             },
             {
-                "type": "Extension",
-                "name": "chromosome_location",
-                "value": {
-                    "id": "ga4gh:CL.82tL1yxucvwp5U2Yo4jNYX06pru8zZYl",
-                    "type": "ChromosomeLocation",
-                    "species_id": "taxonomy:9606",
-                    "chr": "11",
-                    "start": "q23.3",
-                    "end": "q23.3"
-                }
+                "name": "ncbi_locations",
+                "value": [
+                    {
+                        "id": "ga4gh:CL.82tL1yxucvwp5U2Yo4jNYX06pru8zZYl",
+                        "type": "ChromosomeLocation",
+                        "species_id": "taxonomy:9606",
+                        "chr": "11",
+                        "start": "q23.3",
+                        "end": "q23.3"
+                    },
+                    {
+                        "id": "ga4gh:SL.zfPjFTCoZIj-gz5tEBDQwKEOfGBxF9kF",
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.2NkFm8HK88MqeNkCgj78KidCAXgnsfV1",
+                        "start": {
+                            "type": "Number",
+                            "value": 117135528
+                        },
+                        "end": {
+                            "type": "Number",
+                            "value": 117138867
+                        }
+                    }
+                ]
             },
             {
                 "type": "Extension",
@@ -879,8 +1083,14 @@ def compare_gene_descriptor(test, actual):
                 if actual_ext.name == test_ext.name:
                     assert isinstance(actual_ext.value, type(test_ext.value))
                     if isinstance(test_ext.value, list):
-                        assert set(actual_ext.value) == \
-                               set(test_ext.value), f"{test_ext.value} value"
+                        if test_ext.value:
+                            if isinstance(test_ext.value[0], dict):
+                                assert actual_ext.value == test_ext.value
+                            else:
+                                assert set(actual_ext.value) == \
+                                    set(test_ext.value), f"{test_ext.value} value"
+                        else:
+                            assert actual_ext.value == test_ext.value
                     else:
                         assert actual_ext.value == test_ext.value
                     assert actual_ext.type == test_ext.type

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -968,6 +968,61 @@ def normalize_unmerged_ache():
     }
 
 
+@pytest.fixture(scope="module")
+def normalized_ifnr():
+    """Return normalized Gene Descriptor for IFNR."""
+    params = {
+        "id": "normalize.gene:IFNR",
+        "type": "GeneDescriptor",
+        "gene": "hgnc:5447",
+        "label": "IFNR",
+        "xrefs": {
+            "ncbigene:3466"
+        },
+        "alternate_labels": [
+            "IFNGM",
+            "IFNGM2"
+        ],
+        "extensions": [
+            {
+                "name": "approved_name",
+                "value": "interferon production regulator",
+                "type": "Extension"
+            },
+            {
+                "name": "symbol_status",
+                "value": "approved",
+                "type": "Extension"
+            },
+            {
+                "name": "associated_with",
+                "value": [
+                    "pubmed:1906174",
+                    "omim:147573",
+                    "pubmed:1193239"
+                ],
+                "type": "Extension"
+            },
+            {
+                "name": "ncbi_gene_type",
+                "type": "Extension",
+                "value": "unknown"
+            },
+            {
+                "name": "hgnc_locus_type",
+                "type": "Extension",
+                "value": "unknown"
+            },
+            {
+                "name": "location_annotations",
+                "type": "Extension",
+                "value": ["16"]
+            }
+        ]
+    }
+    return GeneDescriptor(**params)
+
+
 @pytest.fixture(scope='module')
 def num_sources():
     """Get the number of sources."""
@@ -1420,6 +1475,17 @@ def test_normalize_single_entry(query_handler, normalized_loc_653303):
     resp = query_handler.normalize(q)
     compare_normalize_resp(resp, q, MatchType.SYMBOL, normalized_loc_653303,
                            expected_source_meta=[SourceName.NCBI.value])
+
+
+def test_normalize_no_locations(query_handler, normalized_ifnr):
+    """Test that the normalized endpoint correcly shapes merged entity with no
+    locations
+    """
+    q = "IFNR"
+    resp = query_handler.normalize(q)
+    compare_normalize_resp(
+        resp, q, MatchType.SYMBOL, normalized_ifnr,
+        expected_source_meta=[SourceName.HGNC.value, SourceName.NCBI.value])
 
 
 def test_normalize_unmerged(query_handler, normalize_unmerged_loc_653303,


### PR DESCRIPTION
close #126 

This also adds `location_annotations` to extensions if the field exists