### PR TITLE
feat: ensure test and aws env vars are not set at same time (staging)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,7 +9,7 @@ jobs:
             AWS_DEFAULT_REGION: us-east-2
             AWS_DEFAULT_OUTPUT: text
             GENE_NORM_DB_URL: http://localhost:8000
-            TEST: GENE_TEST
+            GENE_TEST: true
         steps:
             - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ pre-commit install
 
 ### Running unit tests
 
+By default, tests will employ an existing DynamoDB database. For test environments where this is unavailable (e.g. in CI), the `GENE_TEST` environment variable can be set to initialize a local DynamoDB instance with miniature versions of input data files before tests are executed.
+
+```commandline
+export GENE_TEST=true
+```
+
 Running unit tests is as easy as pytest.
 
 ```commandline

--- a/gene/version.py
+++ b/gene/version.py
@@ -1,2 +1,2 @@
 """Gene normalizer version"""
-__version__ = "0.2.6"
+__version__ = "0.2.7"


### PR DESCRIPTION
Added an extra safety check in the test_database_and_etl. Theoretically it should never happen since an exception would be raised in the db init, but added just in case the env var changes and it is not updated in the tests. 