### PR TITLE
build: update ga4gh packages to use VRS 1.3 models

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,8 @@ fastapi = "*"
 uvicorn = "*"
 click = "*"
 boto3 = "*"
-"ga4gh.vrsatile.pydantic" = "~=0.0.11"
-"ga4gh.vrs" = "~=0.7.8"
+"ga4gh.vrsatile.pydantic" = "~=0.0.12"
+"ga4gh.vrs" = "~=0.8.1"
 
 [dev-packages]
 gene = {editable = true, path = "."}

--- a/gene/version.py
+++ b/gene/version.py
@@ -1,2 +1,2 @@
 """Gene normalizer version"""
-__version__ = "0.1.34"
+__version__ = "0.1.35"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,133 +1,130 @@
 -i https://pypi.org/simple
-alabaster==0.7.13; python_version >= '3.6'
-anyio==3.6.2; python_full_version >= '3.6.2'
+alabaster==0.7.13 ; python_version >= '3.6'
+anyio==3.6.2 ; python_full_version >= '3.6.2'
 appdirs==1.4.4
-appnope==0.1.3; platform_system == 'Darwin'
-argcomplete==3.0.5; python_version >= '3.6'
-argh==0.28.1; python_version >= '3.8'
+appnope==0.1.3 ; platform_system == 'Darwin'
+argcomplete==3.0.5 ; python_version >= '3.6'
+argh==0.28.1 ; python_version >= '3.8'
 asttokens==2.2.1
-attrs==22.2.0; python_version >= '3.6'
-babel==2.12.1; python_version >= '3.7'
+attrs==23.1.0 ; python_version >= '3.7'
+babel==2.12.1 ; python_version >= '3.7'
 backcall==0.2.0
-beautifulsoup4==4.12.0; python_version >= '3.6'
+beautifulsoup4==4.12.2 ; python_full_version >= '3.6.0'
 biocommons.seqrepo==0.6.5
-bioutils==0.5.7; python_version >= '3.6'
-boto3==1.26.104
-botocore==1.29.104; python_version >= '3.7'
+bioutils==0.5.7 ; python_version >= '3.6'
+boto3==1.26.117
+botocore==1.29.117 ; python_version >= '3.7'
 bs4==0.0.1
-canonicaljson==2.0.0; python_version >= '3.7'
-certifi==2022.12.7; python_version >= '3.6'
-cfgv==3.3.1; python_full_version >= '3.6.1'
-charset-normalizer==3.1.0; python_version >= '3.7'
+canonicaljson==2.0.0 ; python_version >= '3.7'
+certifi==2022.12.7 ; python_version >= '3.6'
+cfgv==3.3.1 ; python_full_version >= '3.6.1'
+charset-normalizer==3.1.0 ; python_full_version >= '3.7.0'
 click==8.1.3
-coloredlogs==15.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-comm==0.1.3; python_version >= '3.6'
-coverage[toml]==7.2.2; python_version >= '3.7'
-cssselect==1.2.0; python_version >= '3.7'
-debugpy==1.6.6; python_version >= '3.7'
-decorator==5.1.1; python_version >= '3.5'
+coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+comm==0.1.3 ; python_version >= '3.6'
+coverage[toml]==7.2.3 ; python_version >= '3.7'
+cssselect==1.2.0 ; python_version >= '3.7'
+cython==0.29.34 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+debugpy==1.6.7 ; python_version >= '3.7'
+decorator==5.1.1 ; python_version >= '3.5'
 distlib==0.3.6
-docutils==0.19; python_version >= '3.7'
-exceptiongroup==1.1.1; python_version < '3.11'
+docutils==0.19 ; python_version >= '3.7'
 executing==1.2.0
 fake-useragent==1.1.3
-fastapi==0.95.0
-filelock==3.10.7; python_version >= '3.7'
+fastapi==0.95.1
+filelock==3.12.0 ; python_version >= '3.7'
 flake8==6.0.0
 flake8-docstrings==1.7.0
-ga4gh.vrs==0.7.8
-ga4gh.vrsatile.pydantic==0.0.11
--e .
--e .
+ga4gh.vrs==0.8.1
+ga4gh.vrsatile.pydantic==0.0.12
 gffutils==0.11.1
-h11==0.14.0; python_version >= '3.7'
-humanfriendly==10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-identify==2.5.22; python_version >= '3.7'
-idna==3.4; python_version >= '3.5'
-imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-importlib-metadata==6.1.0; python_version < '3.10'
-importlib-resources==5.12.0; python_version < '3.10'
-inflection==0.5.1; python_version >= '3.5'
-iniconfig==2.0.0; python_version >= '3.7'
+h11==0.14.0 ; python_version >= '3.7'
+humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+identify==2.5.22 ; python_version >= '3.7'
+idna==3.4 ; python_version >= '3.5'
+imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==6.5.0 ; python_version >= '3.7'
+inflection==0.5.1 ; python_version >= '3.5'
+iniconfig==2.0.0 ; python_version >= '3.7'
 ipykernel==6.22.0
-ipython==8.12.0; python_version >= '3.8'
-jedi==0.18.2; python_version >= '3.6'
-jinja2==3.1.2; python_version >= '3.7'
-jmespath==1.0.1; python_version >= '3.7'
+ipython==8.12.0 ; python_version >= '3.8'
+jedi==0.18.2 ; python_version >= '3.6'
+jinja2==3.1.2 ; python_version >= '3.7'
+jmespath==1.0.1 ; python_version >= '3.7'
 jsonschema==3.2.0
-jupyter-client==8.1.0; python_version >= '3.8'
-jupyter-core==5.3.0; python_version >= '3.8'
-lxml==4.9.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-markdown==3.4.3; python_version >= '3.7'
-markupsafe==2.1.2; python_version >= '3.7'
-matplotlib-inline==0.1.6; python_version >= '3.5'
-mccabe==0.7.0; python_version >= '3.6'
-mock==5.0.1
-nest-asyncio==1.5.6; python_version >= '3.5'
-nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-numpy==1.24.2; python_version >= '3.8'
-packaging==23.0; python_version >= '3.7'
+jupyter-client==8.2.0 ; python_version >= '3.8'
+jupyter-core==5.3.0 ; python_version >= '3.8'
+lxml==4.9.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+markdown==3.4.3 ; python_version >= '3.7'
+markupsafe==2.1.2 ; python_version >= '3.7'
+matplotlib-inline==0.1.6 ; python_version >= '3.5'
+mccabe==0.7.0 ; python_version >= '3.6'
+mock==5.0.2
+nest-asyncio==1.5.6 ; python_version >= '3.5'
+nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
+numpy==1.24.2 ; python_version >= '3.8'
+packaging==23.1 ; python_version >= '3.7'
 parse==1.19.0
-parso==0.8.3; python_version >= '3.6'
-pexpect==4.8.0; sys_platform != 'win32'
+parso==0.8.3 ; python_version >= '3.6'
+pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
-platformdirs==3.2.0; python_version >= '3.7'
-pluggy==1.0.0; python_version >= '3.6'
-pre-commit==3.2.1
-prompt-toolkit==3.0.38; python_version >= '3.7'
-psutil==5.9.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+platformdirs==3.2.0 ; python_version >= '3.7'
+pluggy==1.0.0 ; python_version >= '3.6'
+pre-commit==3.2.2
+prompt-toolkit==3.0.38 ; python_full_version >= '3.7.0'
+psutil==5.9.5 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 psycopg[binary]==3.1.8
 psycopg-binary==3.1.8
 ptyprocess==0.7.0
 pure-eval==0.2.2
-pycodestyle==2.10.0; python_version >= '3.6'
+pycodestyle==2.10.0 ; python_version >= '3.6'
 pydantic==1.10.7
-pydocstyle==6.3.0; python_version >= '3.6'
+pydocstyle==6.3.0 ; python_version >= '3.6'
 pyee==8.2.2
-pyfaidx==0.7.2.1; python_version >= '3.7'
-pyflakes==3.0.1; python_version >= '3.6'
-pygments==2.14.0; python_version >= '3.6'
-pyppeteer==1.0.2; python_version >= '3.7' and python_version < '4.0'
+pyfaidx==0.7.2.1 ; python_version >= '3.7'
+pyflakes==3.0.1 ; python_version >= '3.6'
+pygments==2.15.1 ; python_version >= '3.7'
+pyppeteer==1.0.2 ; python_version >= '3.7' and python_version < '4.0'
 pyquery==2.0.0
-pyrsistent==0.19.3; python_version >= '3.7'
-pysam==0.20.0
-pytest==7.2.2
+pyrsistent==0.19.3 ; python_version >= '3.7'
+pysam==0.21.0 ; python_version >= '3.6'
+pytest==7.3.1
 pytest-cov==4.0.0
-python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 python-jsonschema-objects==0.4.1
-pyyaml==6.0; python_version >= '3.6'
-pyzmq==25.0.2; python_version >= '3.6'
-requests==2.28.2; python_version >= '3.7' and python_version < '4'
-requests-html==0.10.0; python_version >= '3.6'
-s3transfer==0.6.0; python_version >= '3.7'
-setuptools==67.6.1; python_version >= '3.7'
-simplejson==3.18.4; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-sniffio==1.3.0; python_version >= '3.7'
+pyyaml==6.0 ; python_version >= '3.6'
+pyzmq==25.0.2 ; python_version >= '3.6'
+requests==2.28.2 ; python_version >= '3.7' and python_version < '4'
+requests-html==0.10.0 ; python_full_version >= '3.6.0'
+s3transfer==0.6.0 ; python_version >= '3.7'
+setuptools==67.7.0 ; python_version >= '3.7'
+simplejson==3.19.1 ; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+sniffio==1.3.0 ; python_version >= '3.7'
 snowballstemmer==2.2.0
-soupsieve==2.4; python_version >= '3.7'
+soupsieve==2.4.1 ; python_version >= '3.7'
 sphinx==6.1.3
-sphinx-autodoc-typehints==1.22
-sphinxcontrib-applehelp==1.0.4; python_version >= '3.8'
-sphinxcontrib-devhelp==1.0.2; python_version >= '3.5'
-sphinxcontrib-htmlhelp==2.0.1; python_version >= '3.8'
-sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
-sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
-sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
-sqlparse==0.4.3; python_version >= '3.5'
+sphinx-autodoc-typehints==1.23.0
+sphinxcontrib-applehelp==1.0.4 ; python_version >= '3.8'
+sphinxcontrib-devhelp==1.0.2 ; python_version >= '3.5'
+sphinxcontrib-htmlhelp==2.0.1 ; python_version >= '3.8'
+sphinxcontrib-jsmath==1.0.1 ; python_version >= '3.5'
+sphinxcontrib-qthelp==1.0.3 ; python_version >= '3.5'
+sphinxcontrib-serializinghtml==1.1.5 ; python_version >= '3.5'
+sqlparse==0.4.4 ; python_version >= '3.5'
 stack-data==0.6.2
-starlette==0.26.1; python_version >= '3.7'
-tabulate==0.9.0; python_version >= '3.7'
-tomli==2.0.1; python_version < '3.11'
-tornado==6.2; python_version >= '3.7'
-tqdm==4.65.0; python_version >= '3.7'
-traitlets==5.9.0; python_version >= '3.7'
-typing-extensions==4.5.0; python_version >= '3.7'
-urllib3==1.26.15; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+starlette==0.26.1 ; python_version >= '3.7'
+tabulate==0.9.0 ; python_version >= '3.7'
+tornado==6.3 ; python_version >= '3.8'
+tqdm==4.65.0 ; python_version >= '3.7'
+traitlets==5.9.0 ; python_version >= '3.7'
+typing-extensions==4.5.0 ; python_version >= '3.7'
+urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 uvicorn==0.21.1
-virtualenv==20.21.0; python_version >= '3.7'
-w3lib==2.1.1; python_version >= '3.7'
+virtualenv==20.22.0 ; python_version >= '3.7'
+w3lib==2.1.1 ; python_version >= '3.7'
 wcwidth==0.2.6
-websockets==10.4; python_version >= '3.7'
+websockets==10.4 ; python_version >= '3.7'
+-e .
 yoyo-migrations==8.2.0
-zipp==3.15.0; python_version >= '3.7'
+zipp==3.15.0 ; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,36 @@
 -i https://pypi.org/simple
-anyio==3.6.2; python_full_version >= '3.6.2'
-attrs==22.2.0; python_version >= '3.6'
-bioutils==0.5.7; python_version >= '3.6'
-boto3==1.26.104
-botocore==1.29.104; python_version >= '3.7'
-canonicaljson==2.0.0; python_version >= '3.7'
-certifi==2022.12.7; python_version >= '3.6'
-charset-normalizer==3.1.0; python_version >= '3.7'
+anyio==3.6.2 ; python_full_version >= '3.6.2'
+attrs==23.1.0 ; python_version >= '3.7'
+bioutils==0.5.7 ; python_version >= '3.6'
+boto3==1.26.117
+botocore==1.29.117 ; python_version >= '3.7'
+canonicaljson==2.0.0 ; python_version >= '3.7'
+certifi==2022.12.7 ; python_version >= '3.6'
+charset-normalizer==3.1.0 ; python_full_version >= '3.7.0'
 click==8.1.3
-coloredlogs==15.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-fastapi==0.95.0
-ga4gh.vrs==0.7.8
-ga4gh.vrsatile.pydantic==0.0.11
-h11==0.14.0; python_version >= '3.7'
-humanfriendly==10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-idna==3.4; python_version >= '3.5'
-importlib-metadata==6.1.0; python_version < '3.10'
-inflection==0.5.1; python_version >= '3.5'
-jmespath==1.0.1; python_version >= '3.7'
+coloredlogs==15.0.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+fastapi==0.95.1
+ga4gh.vrs==0.8.1
+ga4gh.vrsatile.pydantic==0.0.12
+h11==0.14.0 ; python_version >= '3.7'
+humanfriendly==10.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+idna==3.4 ; python_version >= '3.5'
+inflection==0.5.1 ; python_version >= '3.5'
+jmespath==1.0.1 ; python_version >= '3.7'
 jsonschema==3.2.0
-markdown==3.4.3; python_version >= '3.7'
-numpy==1.24.2; python_version >= '3.8'
+markdown==3.4.3 ; python_version >= '3.7'
+numpy==1.24.2 ; python_version >= '3.8'
 pydantic==1.10.7
-pyrsistent==0.19.3; python_version >= '3.7'
-python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyrsistent==0.19.3 ; python_version >= '3.7'
+python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 python-jsonschema-objects==0.4.1
-pyyaml==6.0; python_version >= '3.6'
-requests==2.28.2; python_version >= '3.7' and python_version < '4'
-s3transfer==0.6.0; python_version >= '3.7'
-setuptools==67.6.1; python_version >= '3.7'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-sniffio==1.3.0; python_version >= '3.7'
-starlette==0.26.1; python_version >= '3.7'
-typing-extensions==4.5.0; python_version >= '3.7'
-urllib3==1.26.15; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+pyyaml==6.0 ; python_version >= '3.6'
+requests==2.28.2 ; python_version >= '3.7' and python_version < '4'
+s3transfer==0.6.0 ; python_version >= '3.7'
+setuptools==67.7.0 ; python_version >= '3.7'
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+sniffio==1.3.0 ; python_version >= '3.7'
+starlette==0.26.1 ; python_version >= '3.7'
+typing-extensions==4.5.0 ; python_version >= '3.7'
+urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 uvicorn==0.21.1
-zipp==3.15.0; python_version >= '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ install_requires =
     uvicorn
     click
     boto3
-    ga4gh.vrsatile.pydantic ~= 0.0.11
-    ga4gh.vrs ~= 0.7.8
+    ga4gh.vrsatile.pydantic ~= 0.0.12
+    ga4gh.vrs ~= 0.8.1
 
 tests_require =
     pytest


### PR DESCRIPTION
Close #131 

Notes:
- ga4gh.vrsatile.pydantic ~= 0.0.12
- ga4gh.vrs ~= 0.8.1