### PR TITLE
feat: add DB status check entrypoint

### DIFF
--- a/docs/source/managing_data/loading_and_updating_data.rst
+++ b/docs/source/managing_data/loading_and_updating_data.rst
@@ -18,3 +18,11 @@ To update specific sources, use the ``--normalizer`` option along with source na
 
     gene_norm_update --normalizer="HGNC NCBI" --update_merged
 
+Check DB health
+---------------
+
+The shell command `gene_norm_check_db` performs a basic check on the database status. It first confirms that the database's schema exists, and then identifies whether metadata is available for each source, and whether gene record and normalized concept tables are non-empty. Check the process's exit code for the result.
+
+    % gene_norm_check_db
+    % echo $?
+    1  # indicates failure

--- a/gene/cli.py
+++ b/gene/cli.py
@@ -23,6 +23,32 @@ logger.setLevel(logging.DEBUG)
 
 
 @click.command()
+@click.option("--db_url", help="URL endpoint for the application database.")
+@click.option("--verbose", "-v", is_flag=True, help="Print result to console if set.")
+def check_db(db_url: str, verbose: bool = False) -> None:
+    """Perform basic checks on DB health and population. Exits with status code 1
+    if DB schema is uninitialized or if critical tables appear to be empty.
+
+    \f
+    :param db_url: URL to normalizer database
+    :param verbose: if true, print result to console
+    """  # noqa: D301
+    db = create_db(db_url, False)
+    if not db.check_schema_initialized():
+        if verbose:
+            click.echo("Health check failed: DB schema uninitialized.")
+        click.get_current_context().exit(1)
+
+    if not db.check_tables_populated():
+        if verbose:
+            click.echo("Health check failed: DB is incompletely populated.")
+        click.get_current_context().exit(1)
+
+    if verbose:
+        click.echo("DB health check successful: tables appear complete.")
+
+
+@click.command()
 @click.option("--data_url", help="URL to data dump")
 @click.option("--db_url", help="URL endpoint for the application database.")
 def update_from_remote(data_url: Optional[str], db_url: str) -> None:

--- a/gene/database/database.py
+++ b/gene/database/database.py
@@ -77,10 +77,30 @@ class AbstractDatabase(abc.ABC):
         """
 
     @abc.abstractmethod
+    def check_schema_initialized(self) -> bool:
+        """Check if database schema is properly initialized.
+
+        :return: True if DB appears to be fully initialized, False otherwise
+        """
+
+    @abc.abstractmethod
+    def check_tables_populated(self) -> bool:
+        """Perform rudimentary checks to see if tables are populated.
+
+        Emphasis is on rudimentary -- if some rogueish element has deleted half of the
+        gene aliases, this method won't pick it up. It just wants to see if a few
+        critical tables have at least a small number of records.
+
+        :return: True if queries successful, false if DB appears empty
+        """
+
+    @abc.abstractmethod
     def initialize_db(self) -> None:
         """Perform all necessary parts of database setup. Should be tolerant of
         existing content -- ie, this method is also responsible for checking whether
         the DB is already set up.
+
+        :raise DatabaseInitializationException: if initialization fails
         """
 
     @abc.abstractmethod

--- a/gene/database/dynamodb.py
+++ b/gene/database/dynamodb.py
@@ -13,7 +13,8 @@ import click
 from gene import ITEM_TYPES, PREFIX_LOOKUP
 from gene.database.database import AWS_ENV_VAR_NAME, SKIP_AWS_DB_ENV_NAME, \
     VALID_AWS_ENV_NAMES, AbstractDatabase, AwsEnvName, DatabaseException, \
-    DatabaseReadException, DatabaseWriteException, confirm_aws_db_use
+    DatabaseInitializationException, DatabaseReadException, DatabaseWriteException, \
+    confirm_aws_db_use
 from gene.schemas import RefType, SourceMeta, SourceName
 
 logger = logging.getLogger()
@@ -70,10 +71,7 @@ class DynamoDbDatabase(AbstractDatabase):
         self.dynamodb = boto3.resource('dynamodb', **boto_params)
         self.dynamodb_client = boto3.client('dynamodb', **boto_params)
 
-        # Only create tables for local instance
-        envs_do_not_create_tables = {AWS_ENV_VAR_NAME, "GENE_TEST"}
-        if not set(envs_do_not_create_tables) & set(environ):
-            self.initialize_db()
+        self.initialize_db()
 
         self.genes = self.dynamodb.Table(gene_concepts_table)
         self.metadata = self.dynamodb.Table(gene_metadata_table)
@@ -104,116 +102,154 @@ class DynamoDbDatabase(AbstractDatabase):
         for table_name in existing_tables:
             self.dynamodb.Table(table_name).delete()
 
-    def _create_genes_table(self, existing_tables: List[str]):
-        """Create Genes table if non-existent.
-
-        :param List[str] existing_tables: table names already in DB
-        """
-        table_name = 'gene_concepts'
-        if table_name not in existing_tables:
-            self.dynamodb.create_table(
-                TableName=table_name,
-                KeySchema=[
-                    {
-                        'AttributeName': 'label_and_type',
-                        'KeyType': 'HASH'  # Partition key
-                    },
-                    {
-                        'AttributeName': 'concept_id',
-                        'KeyType': 'RANGE'  # Sort key
-                    }
-                ],
-                AttributeDefinitions=[
-                    {
-                        'AttributeName': 'label_and_type',
-                        'AttributeType': 'S'
-                    },
-                    {
-                        'AttributeName': 'concept_id',
-                        'AttributeType': 'S'
-                    },
-                    {
-                        'AttributeName': 'src_name',
-                        'AttributeType': 'S'
-                    },
-                    {
-                        'AttributeName': 'item_type',
-                        'AttributeType': 'S'
-                    }
-
-                ],
-                GlobalSecondaryIndexes=[
-                    {
-                        'IndexName': 'src_index',
-                        'KeySchema': [
-                            {
-                                'AttributeName': 'src_name',
-                                'KeyType': 'HASH'
-                            }
-                        ],
-                        'Projection': {
-                            'ProjectionType': 'KEYS_ONLY'
-                        },
-                        'ProvisionedThroughput': {
-                            'ReadCapacityUnits': 10,
-                            'WriteCapacityUnits': 10
-                        }
-                    },
-                    {
-                        'IndexName': 'item_type_index',
-                        'KeySchema': [
-                            {
-                                'AttributeName': 'item_type',
-                                'KeyType': 'HASH'
-                            }
-                        ],
-                        'Projection': {
-                            'ProjectionType': 'KEYS_ONLY'
-                        },
-                        'ProvisionedThroughput': {
-                            'ReadCapacityUnits': 10,
-                            'WriteCapacityUnits': 10
-                        }
-                    }
-                ],
-                ProvisionedThroughput={
-                    'ReadCapacityUnits': 10,
-                    'WriteCapacityUnits': 10
+    def _create_genes_table(self):
+        """Create Genes table."""
+        self.dynamodb.create_table(
+            TableName="gene_concepts",
+            KeySchema=[
+                {
+                    'AttributeName': 'label_and_type',
+                    'KeyType': 'HASH'  # Partition key
+                },
+                {
+                    'AttributeName': 'concept_id',
+                    'KeyType': 'RANGE'  # Sort key
                 }
-            )
-
-    def _create_meta_data_table(self, existing_tables: List[str]) -> None:
-        """Create MetaData table if non-existent.
-
-        :param List[str] existing_tables: table names already in DB
-        """
-        table_name = 'gene_metadata'
-        if table_name not in existing_tables:
-            self.dynamodb.create_table(
-                TableName=table_name,
-                KeySchema=[
-                    {
-                        'AttributeName': 'src_name',
-                        'KeyType': 'HASH'  # Partition key
-                    }
-                ],
-                AttributeDefinitions=[
-                    {
-                        'AttributeName': 'src_name',
-                        'AttributeType': 'S'
-                    },
-                ],
-                ProvisionedThroughput={
-                    'ReadCapacityUnits': 10,
-                    'WriteCapacityUnits': 10
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'label_and_type',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'concept_id',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'src_name',
+                    'AttributeType': 'S'
+                },
+                {
+                    'AttributeName': 'item_type',
+                    'AttributeType': 'S'
                 }
-            )
+
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    'IndexName': 'src_index',
+                    'KeySchema': [
+                        {
+                            'AttributeName': 'src_name',
+                            'KeyType': 'HASH'
+                        }
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'KEYS_ONLY'
+                    },
+                    'ProvisionedThroughput': {
+                        'ReadCapacityUnits': 10,
+                        'WriteCapacityUnits': 10
+                    }
+                },
+                {
+                    'IndexName': 'item_type_index',
+                    'KeySchema': [
+                        {
+                            'AttributeName': 'item_type',
+                            'KeyType': 'HASH'
+                        }
+                    ],
+                    'Projection': {
+                        'ProjectionType': 'KEYS_ONLY'
+                    },
+                    'ProvisionedThroughput': {
+                        'ReadCapacityUnits': 10,
+                        'WriteCapacityUnits': 10
+                    }
+                }
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 10,
+                'WriteCapacityUnits': 10
+            }
+        )
+
+    def _create_meta_data_table(self) -> None:
+        """Create MetaData table if non-existent."""
+        self.dynamodb.create_table(
+            TableName="gene_metadata",
+            KeySchema=[
+                {
+                    'AttributeName': 'src_name',
+                    'KeyType': 'HASH'  # Partition key
+                }
+            ],
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'src_name',
+                    'AttributeType': 'S'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 10,
+                'WriteCapacityUnits': 10
+            }
+        )
+
+    def check_schema_initialized(self) -> bool:
+        """Check if database schema is properly initialized.
+
+        :return: True if DB appears to be fully initialized, False otherwise
+        """
+        existing_tables = self.list_tables()
+        return "gene_concepts" in existing_tables and "gene_metadata" in existing_tables
+
+    def check_tables_populated(self) -> bool:
+        """Perform rudimentary checks to see if tables are populated.
+
+        Emphasis is on rudimentary -- if some rogueish element has deleted half of the
+        gene aliases, this method won't pick it up. It just wants to see if a few
+        critical tables have at least a small number of records.
+
+        :return: True if queries successful, false if DB appears empty
+        """
+        sources = self.metadata.scan().get("Items", [])
+        if len(sources) < len(SourceName):
+            return False
+
+        records = self.genes.query(
+            IndexName="item_type_index",
+            KeyConditionExpression=Key("item_type").eq("identity"),
+            Limit=1
+        )
+        if len(records.get("Items", [])) < 1:
+            return False
+
+        normalized_records = self.genes.query(
+            IndexName="item_type_index",
+            KeyConditionExpression=Key("item_type").eq("merger"),
+            Limit=1
+        )
+        if len(normalized_records.get("Items", [])) < 1:
+            return False
+
+        return True
 
     def initialize_db(self) -> None:
-        """Create gene_concepts and gene_metadata tables."""
-        existing_tables = self.list_tables()
-        self._create_genes_table(existing_tables)
-        self._create_meta_data_table(existing_tables)
+        """Create gene_concepts and gene_metadata tables if not already created.
+
+        :raise DatabaseInitializationException: if schema is uninitialized and in
+        an environment that requires manual creation, e.g. production.
+        """
+        if not self.check_schema_initialized():
+            # Only create tables for local instance
+            envs_do_not_create_tables = {AWS_ENV_VAR_NAME, "GENE_TEST"}
+            if not set(envs_do_not_create_tables) & set(environ):
+                self._create_genes_table()
+                self._create_meta_data_table()
+            else:
+                raise DatabaseInitializationException("DynamoDB schema uninitialized.")
 
     def get_source_metadata(self, src_name: Union[str, SourceName]) -> Dict:
         """Get license, versioning, data lookup, etc information for a source.

--- a/gene/database/postgresql.py
+++ b/gene/database/postgresql.py
@@ -19,8 +19,7 @@ from gene.database import AbstractDatabase, DatabaseException, DatabaseReadExcep
 from gene.schemas import RefType, SourceMeta, SourceName
 
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 SCRIPTS_DIR = Path(__file__).parent / "postgresql"
@@ -166,18 +165,21 @@ class PostgresDatabase(AbstractDatabase):
             cur.execute("SELECT name FROM gene_sources;")
             results = cur.fetchall()
         if len(results) < len(SourceName):
+            logger.info("Gene sources table is missing expected sources.")
             return False
 
         with self.conn.cursor() as cur:
             cur.execute("SELECT COUNT(1) FROM gene_concepts LIMIT 1;")
             result = cur.fetchone()
         if not result or result[0] < 1:
+            logger.info("Gene records table is empty.")
             return False
 
         with self.conn.cursor() as cur:
             cur.execute("SELECT COUNT(1) FROM gene_merged LIMIT 1;")
             result = cur.fetchone()
         if not result or result[0] < 1:
+            logger.info("Normalized gene records table is empty.")
             return False
 
         return True

--- a/gene/database/postgresql/add_indexes.sql
+++ b/gene/database/postgresql/add_indexes.sql
@@ -1,13 +1,13 @@
-CREATE INDEX IF NOT EXISTS idx_g_concept_id_low
+CREATE INDEX idx_g_concept_id_low
     ON gene_concepts (lower(concept_id));
-CREATE INDEX IF NOT EXISTS idx_gm_concept_id_low
+CREATE INDEX idx_gm_concept_id_low
     ON gene_merged (lower(concept_id));
-CREATE INDEX IF NOT EXISTS idx_gs_symbol_low ON gene_symbols (lower(symbol));
-CREATE INDEX IF NOT EXISTS idx_gps_symbol_low
+CREATE INDEX idx_gs_symbol_low ON gene_symbols (lower(symbol));
+CREATE INDEX idx_gps_symbol_low
     ON gene_previous_symbols (lower(prev_symbol));
-CREATE INDEX IF NOT EXISTS idx_ga_alias_low ON gene_aliases (lower(alias));
-CREATE INDEX IF NOT EXISTS idx_gx_xref_low ON gene_xrefs (lower(xref));
-CREATE INDEX IF NOT EXISTS idx_g_as_association_low
+CREATE INDEX idx_ga_alias_low ON gene_aliases (lower(alias));
+CREATE INDEX idx_gx_xref_low ON gene_xrefs (lower(xref));
+CREATE INDEX idx_g_as_association_low
     ON gene_associations (lower(associated_with));
-CREATE INDEX IF NOT EXISTS idx_rlv_concept_id_low
+CREATE INDEX idx_rlv_concept_id_low
     ON record_lookup_view (lower(concept_id));

--- a/gene/database/postgresql/create_record_lookup_view.sql
+++ b/gene/database/postgresql/create_record_lookup_view.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS record_lookup_view AS
+CREATE MATERIALIZED VIEW record_lookup_view AS
 SELECT gc.concept_id,
        gc.symbol_status,
        gc.label,

--- a/gene/database/postgresql/create_tables.sql
+++ b/gene/database/postgresql/create_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS gene_sources (
+CREATE TABLE gene_sources (
     name VARCHAR(127) PRIMARY KEY,
     data_license TEXT NOT NULL,
     data_license_url TEXT NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS gene_sources (
     data_license_sa BOOLEAN NOT NULL,
     genome_assemblies TEXT [] NOT NULL
 );
-CREATE TABLE IF NOT EXISTS gene_merged (
+CREATE TABLE gene_merged (
     concept_id VARCHAR(127) PRIMARY KEY,
     symbol TEXT,
     symbol_status VARCHAR(127),
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS gene_merged (
     associated_with TEXT [],
     xrefs TEXT []
 );
-CREATE TABLE IF NOT EXISTS gene_concepts (
+CREATE TABLE gene_concepts (
     concept_id VARCHAR(127) PRIMARY KEY,
     source VARCHAR(127) NOT NULL REFERENCES gene_sources (name),
     symbol_status VARCHAR(127),
@@ -39,27 +39,27 @@ CREATE TABLE IF NOT EXISTS gene_concepts (
     gene_type TEXT,
     merge_ref VARCHAR(127) REFERENCES gene_merged (concept_id)
 );
-CREATE TABLE IF NOT EXISTS gene_symbols (
+CREATE TABLE gene_symbols (
     id SERIAL PRIMARY KEY,
     symbol TEXT NOT NULL,
     concept_id VARCHAR(127) REFERENCES gene_concepts (concept_id)
 );
-CREATE TABLE IF NOT EXISTS gene_previous_symbols (
+CREATE TABLE gene_previous_symbols (
     id SERIAL PRIMARY KEY,
     prev_symbol TEXT NOT NULL,
     concept_id VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)
 );
-CREATE TABLE IF NOT EXISTS gene_aliases (
+CREATE TABLE gene_aliases (
     id SERIAL PRIMARY KEY,
     alias TEXT NOT NULL,
     concept_id VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)
 );
-CREATE TABLE IF NOT EXISTS gene_xrefs (
+CREATE TABLE gene_xrefs (
     id SERIAL PRIMARY KEY,
     xref TEXT NOT NULL,
     concept_id VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)
 );
-CREATE TABLE IF NOT EXISTS gene_associations (
+CREATE TABLE gene_associations (
     id SERIAL PRIMARY KEY,
     associated_with TEXT NOT NULL,
     concept_ID VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ console_scripts =
     gene_norm_update = gene.cli:update_normalizer_db
     gene_norm_update_remote = gene.cli:update_from_remote
     gene_norm_dump = gene.cli:dump_database
+    gene_norm_check_db = gene.cli:check_db
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Adds a console entrypoint `gene_norm_check_db` that exits with status code 1 if the DB isn't set up or if a few basic queries fail.

Useful for the way I'm trying to get Docker to work.