### PR TITLE
fix: prevent redundant/incorrect AWS confirmation checks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
   - family-names: Wagner
     given-names: Alex
 title: VICC Gene Normalization Service
-version: v0.1.31
-date-released: 2022-12-27
+version: v0.1.36
+date-released: 2023-05-01

--- a/gene/database/database.py
+++ b/gene/database/database.py
@@ -242,19 +242,9 @@ def create_db(
     :param aws_instance: use hosted DynamoDB instance, not local DB
     :return: constructed Database instance
     """
-    # If SKIP_AWS_CONFIRMATION is accidentally set, we should verify that the
-    # aws instance should actually be used
-    invalid_aws_msg = f"{AWS_ENV_VAR_NAME} must be set to one of {VALID_AWS_ENV_NAMES}"
-    aws_env_var_set = False
-    if AWS_ENV_VAR_NAME in environ:
-        aws_env_var_set = True
-        assert environ[AWS_ENV_VAR_NAME] in VALID_AWS_ENV_NAMES, invalid_aws_msg
-        confirm_aws_db_use(environ[AWS_ENV_VAR_NAME].upper())
+    aws_env_var_set = AWS_ENV_VAR_NAME in environ
 
     if aws_env_var_set or aws_instance:
-        assert AWS_ENV_VAR_NAME in environ, invalid_aws_msg
-        environ[SKIP_AWS_DB_ENV_NAME] = "true"  # this is already checked above
-
         from gene.database.dynamodb import DynamoDbDatabase
         db = DynamoDbDatabase()
     else:

--- a/gene/version.py
+++ b/gene/version.py
@@ -1,2 +1,2 @@
 """Gene normalizer version"""
-__version__ = "0.1.35"
+__version__ = "0.1.36"


### PR DESCRIPTION
close #188 

per slack, these checks are already performed on dynamodb initialization and not necessary in the DB helper