### PR TITLE
perf: improve PG normalized concept deletion

### DIFF
--- a/gene/database/postgresql/add_indexes.sql
+++ b/gene/database/postgresql/add_indexes.sql
@@ -1,7 +1,7 @@
 CREATE INDEX idx_g_concept_id_low
     ON gene_concepts (lower(concept_id));
-CREATE INDEX idx_gm_concept_id_low
-    ON gene_merged (lower(concept_id));
+-- see also: delete_normalized_concepts.sql
+CREATE INDEX idx_gm_concept_id_low ON gene_merged (lower(concept_id));
 CREATE INDEX idx_gs_symbol_low ON gene_symbols (lower(symbol));
 CREATE INDEX idx_gps_symbol_low
     ON gene_previous_symbols (lower(prev_symbol));

--- a/gene/database/postgresql/create_tables.sql
+++ b/gene/database/postgresql/create_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE gene_sources (
     data_license_sa BOOLEAN NOT NULL,
     genome_assemblies TEXT [] NOT NULL
 );
+-- see also: delete_normalized_concepts.sql
 CREATE TABLE gene_merged (
     concept_id VARCHAR(127) PRIMARY KEY,
     symbol TEXT,

--- a/gene/database/postgresql/delete_normalized_concepts.sql
+++ b/gene/database/postgresql/delete_normalized_concepts.sql
@@ -1,0 +1,28 @@
+-- some redundancy between here and create_tables.sql, drop_indexes.sql,
+-- add_indexes.sql.
+DROP INDEX IF EXISTS idx_gm_concept_id_low;
+ALTER TABLE gene_concepts DROP CONSTRAINT IF EXISTS gene_concepts_merge_ref_fkey;
+UPDATE gene_concepts SET merge_ref = NULL;
+DROP TABLE gene_merged;
+CREATE TABLE gene_merged (
+    concept_id VARCHAR(127) PRIMARY KEY,
+    symbol TEXT,
+    symbol_status VARCHAR(127),
+    previous_symbols TEXT [],
+    label TEXT,
+    strand VARCHAR(1),
+    ensembl_locations JSON [],
+    hgnc_locations JSON [],
+    ncbi_locations JSON [],
+    location_annotations TEXT [],
+    ensembl_biotype TEXT [],
+    hgnc_locus_type TEXT [],
+    ncbi_gene_type TEXT [],
+    aliases TEXT [],
+    associated_with TEXT [],
+    xrefs TEXT []
+);
+ALTER TABLE gene_concepts ADD CONSTRAINT gene_concepts_merge_ref_fkey
+    FOREIGN KEY (merge_ref) REFERENCES gene_merged (concept_id);
+CREATE INDEX idx_gm_concept_id_low
+    ON gene_merged (lower(concept_id));

--- a/gene/database/postgresql/drop_indexes.sql
+++ b/gene/database/postgresql/drop_indexes.sql
@@ -1,5 +1,5 @@
 DROP INDEX IF EXISTS idx_g_concept_id_low;
-DROP INDEX IF EXISTS idx_gm_concept_id_low;
+DROP INDEX IF EXISTS idx_gm_concept_id_low; -- see also: delete_normalized_concepts.sql
 DROP INDEX IF EXISTS idx_gs_symbol_low;
 DROP INDEX IF EXISTS idx_gps_symbol_low;
 DROP INDEX IF EXISTS idx_gx_xref_low;


### PR DESCRIPTION
I might be reaching here, but normalized delete times were sorta slow in postgres because they were iteratively deleting every record in the merged concepts table. This PR adds some repeated SQL code in a few places but basically tears down and reconstructs all of the merged concepts dependencies so you can simply drop the table rather than clearing it row by row. It should be safe since it still happens in one transaction but definitely makes for less elegant code. On the bright side, it's like 10 times faster now.

I also went through and made all the query strings class variables so they're only defined once, rather than being recreated on every method call. This is a teeny tiny optimization but is more in line with how Python apps tend to do this.

