### PR TITLE
docs: provide readthedocs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,4 +7,7 @@ build:
 
 python:
   install:
-    - requirements: requirements-dev.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: requirements-dev.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,8 @@ dev =
     flake8
     flake8-docstrings
     ipykernel
+
+docs =
     sphinx == 6.1.3
     sphinx-autodoc-typehints == 1.22.0
 


### PR DESCRIPTION
Progress on #185. A lot of the automation needs to happen on the rtd side, which is a little unfortunate, but this enables the basics.

see eg https://gene-normalizer.readthedocs.io/en/latest/