### PR TITLE
ci: use latest pip in sphinx test

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -73,5 +73,5 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: 'python3 -m pip install "pydantic~=1.10.9" &&  python3 -m pip install .[docs]'
+          pre-build-command: 'python3 -m pip install --upgrade pip &&  python3 -m pip install .[docs]'
           docs-folder: "docs/"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,14 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: ammaraskar/sphinx-action@master
         with:
-          python-version: '3.10'
-
-      - name: Install docs dependencies
-        run: python3 -m pip install ".[docs]"
-
-      - name: Build docs
-        working-directory: docs/
-        run: make html
+          pre-build-command: 'python3 -m pip install "pydantic~=1.10.9" &&  python3 -m pip install .[docs]'
+          docs-folder: "docs/"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,6 +71,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - uses: ammaraskar/sphinx-action@master
         with:
           pre-build-command: 'python3 -m pip install .[docs]'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -76,7 +76,9 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          pre-build-command: 'python3 -m pip install .[docs]'
-          docs-folder: "docs/"
+      - name: Install docs dependencies
+        run: python3 -m pip install ".[docs]"
+
+      - name: Build docs
+        working-directory: docs/
+        run: make html

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -78,5 +78,5 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: 'python3 -m pip install .[docs]'
+          pre-build-command: 'python3 -m pip install .[etl,test,docs]'
           docs-folder: "docs/"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -78,5 +78,5 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: 'python3 -m pip install .[pg,etl,test,docs]'
+          pre-build-command: 'python3 -m pip install .[docs]'
           docs-folder: "docs/"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -78,5 +78,5 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: 'python3 -m pip install .[etl,test,docs]'
+          pre-build-command: 'python3 -m pip install .[docs]'
           docs-folder: "docs/"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -78,5 +78,5 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: 'python3 -m pip install .[docs]'
+          pre-build-command: 'python3 -m pip install .[pg,etl,test,docs]'
           docs-folder: "docs/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,12 @@ python_requires = >=3.8
 zip_safe = False
 
 install_requires =
-    ga4gh.vrsatile.pydantic ~= 0.0.12
     pydantic
     fastapi
     uvicorn
     click
     boto3
+    ga4gh.vrsatile.pydantic ~= 0.0.12
     ga4gh.vrs ~= 0.8.1
 
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,12 @@ python_requires = >=3.8
 zip_safe = False
 
 install_requires =
+    ga4gh.vrsatile.pydantic ~= 0.0.12
     pydantic
     fastapi
     uvicorn
     click
     boto3
-    ga4gh.vrsatile.pydantic ~= 0.0.12
     ga4gh.vrs ~= 0.8.1
 
 tests_require =


### PR DESCRIPTION
the sphinx test GitHub Action uses a Docker image that has an old version of pip on it, resulting in poor dependency conflict management with respect to Pydantic v1 vs v2. This pr forces it to upgrade to the latest version to ensure that it handles it better.