### PR TITLE
fix: catch ETL module import errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,10 @@ gene =
 
 [options.entry_points]
 console_scripts =
-    gene_norm_update = gene.cli:update_normalizer_db
-    gene_norm_update_remote = gene.cli:update_from_remote
-    gene_norm_dump = gene.cli:dump_database
-    gene_norm_check_db = gene.cli:check_db
+    gene_norm_update = gene.etl.cli:update_normalizer_db
+    gene_norm_update_remote = gene.database.cli:update_from_remote
+    gene_norm_dump = gene.database.cli:dump_database
+    gene_norm_check_db = gene.database.cli:check_db
 
 [options.extras_require]
 pg =

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,10 @@ gene =
 
 [options.entry_points]
 console_scripts =
-    gene_norm_update = gene.etl.cli:update_normalizer_db
-    gene_norm_update_remote = gene.database.cli:update_from_remote
-    gene_norm_dump = gene.database.cli:dump_database
-    gene_norm_check_db = gene.database.cli:check_db
+    gene_norm_update = gene.cli:update_normalizer_db
+    gene_norm_update_remote = gene.cli:update_from_remote
+    gene_norm_dump = gene.cli:dump_database
+    gene_norm_check_db = gene.cli:check_db
 
 [options.extras_require]
 pg =


### PR DESCRIPTION
Resolve #248 

We could compartmentalize this a bit by splitting the ETL-specific functions into a `gene.etl.cli` module and moving everything else to a `gene.database.cli` module, but I think we still need to put the `try import/except` block into the middle of the file CLI rather than the top to avoid other weird side effects.