### PR TITLE
docs: update VRS compliance

### DIFF
--- a/docs/source/normalizing_data/vrs_compliance.rst
+++ b/docs/source/normalizing_data/vrs_compliance.rst
@@ -11,8 +11,8 @@ As mentioned earlier in the documentation, the Gene Normalizer incorporates stru
      - Gene Normalizer version
      - VRS version
    * - `main <https://github.com/cancervariants/gene-normalization>`_
+     - 0.3.x
+     - `2.X <https://github.com/ga4gh/vrs/tree/2.0-alpha>`_
+   * - `vrs-1.x <https://github.com/cancervariants/gene-normalization>`_ (no longer maintained)
      - 0.1.x
      - `1.X <https://github.com/ga4gh/vrs>`_
-   * - `staging <https://github.com/cancervariants/gene-normalization/tree/staging>`_
-     - 0.3.x
-     - `metaschema-update <https://github.com/ga4gh/vrs/tree/2.0-alpha>`_


### PR DESCRIPTION
close #286 

Notes:
* branch updates:
  * `main` --> `vrs-1.x` (VRS 1.x) . Locked branch (rule applies to any branches that match `vrs-*`). Maybe I should just rename to `vrs-1.3`? 
  * `staging` --> `main` (VRS 2.x)
  * We will only work off of `main` branch and no longer need a `staging` branch
* For VRS 1.x, just kept as main branch. Wasn't sure if we wanted to point to 1.3 branch or not. 

@jsstevenson does this work for you? If so, I will go ahead and make these changes for disease and therapy. 
 