### PR TITLE
build: properly pin pydantic v2 major version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pydantic = "*"
+pydantic = "== 2.*"
 fastapi = "*"
 uvicorn = "*"
 click = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.8"
 description = "VICC normalization routines for genes"
 license = {file = "LICENSE"}
 dependencies = [
-    "pydantic",
+    "pydantic==2.*",
     "fastapi",
     "uvicorn",
     "click",


### PR DESCRIPTION
Not updating ga4gh.vrs:

https://peps.python.org/pep-0440/#compatible-release

> If a pre-release, post-release or developmental release is named in a compatible release clause as V.N.suffix, then the suffix is ignored when determining the required prefix match:
> 
> ```
> ~= 1.4.5a4
> >= 1.4.5a4, == 1.4.*
> ```
