### PR TITLE
feat!: collapse `associated_with` into `xrefs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gene Normalizer
 
 ## Overview
 <!-- description -->
-The Gene Normalizer provides tools for resolving ambiguous human gene references to consistently-structured, normalized terms. For gene concepts extracted from [NCBI Gene](https://www.ncbi.nlm.nih.gov/gene/), [Ensembl](https://useast.ensembl.org/index.html), and [HGNC](https://www.genenames.org/), it designates a [CURIE](https://en.wikipedia.org/wiki/CURIE), and provides additional metadata like current and previously-used symbols, aliases, database cross-references and associations, and coordinates.
+The Gene Normalizer provides tools for resolving ambiguous human gene references to consistently-structured, normalized terms. For gene concepts extracted from [NCBI Gene](https://www.ncbi.nlm.nih.gov/gene/), [Ensembl](https://useast.ensembl.org/index.html), and [HGNC](https://www.genenames.org/), it designates a [CURIE](https://en.wikipedia.org/wiki/CURIE), and provides additional metadata like current and previously-used symbols, aliases, database cross-references, and coordinates.
 <!-- /description -->
 ---
 

--- a/docs/scripts/generate_normalize_figure.py
+++ b/docs/scripts/generate_normalize_figure.py
@@ -111,7 +111,7 @@ def gen_norm_figure() -> None:
     )
     fig.export_html(
         (
-            APP_ROOT.parents[0]
+            APP_ROOT.parents[2]
             / "docs"
             / "source"
             / "_static"

--- a/docs/source/_static/html/normalize_example.html
+++ b/docs/source/_static/html/normalize_example.html
@@ -6,25 +6,25 @@
 <body style="margin:0;">
   <style>
     /* Main divisions */
-    #i8EK4UFXUqNxcNnZd-main-div {
+    #imev8OqzlOAPljR9j-main-div {
       line-height: normal;
       box-sizing: content-box;
       padding: 3px;
       background-color: white;
     }
-    #i8EK4UFXUqNxcNnZd-left-div {
+    #imev8OqzlOAPljR9j-left-div {
       float: left;
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-right-div {
+    #imev8OqzlOAPljR9j-right-div {
       float: left;
       height: 100%;
       display: none;
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-right-inner-div {
+    #imev8OqzlOAPljR9j-right-inner-div {
       padding-left: 5px;
       padding-right: 2px;
       overflow-x: hidden;
@@ -35,7 +35,7 @@
     }
 
     /* Graph and details (contained in left-inner-div) */
-    #i8EK4UFXUqNxcNnZd-graph-div {
+    #imev8OqzlOAPljR9j-graph-div {
       overflow: hidden;
       resize: vertical;
       position: relative;
@@ -46,7 +46,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-details-div {
+    #imev8OqzlOAPljR9j-details-div {
       overflow: auto;
       resize: vertical;
       margin-top: 5px;
@@ -57,7 +57,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-details-head {
+    #imev8OqzlOAPljR9j-details-head {
       user-select: none;
       padding-left: 4px !important;
       padding-top: 4px !important;
@@ -67,7 +67,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-details-body {
+    #imev8OqzlOAPljR9j-details-body {
       padding: 10px;
       padding-top: 6px;
       font-size: 10px;
@@ -77,7 +77,7 @@
     }
 
     /* Control menu (contained in right-inner-div) */
-    .i8EK4UFXUqNxcNnZd-menu-item-head {
+    .imev8OqzlOAPljR9j-menu-item-head {
       font-size: 11px;
       font-family: "Lucida Console", Monaco, monospace;
       color: black;
@@ -93,13 +93,13 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    .i8EK4UFXUqNxcNnZd-menu-item-body {
+    .imev8OqzlOAPljR9j-menu-item-body {
       margin-left: 5px;
       margin-bottom: 10px;
       line-height: normal;
       box-sizing: content-box;
     }
-    .i8EK4UFXUqNxcNnZd-menu-subitem-head {
+    .imev8OqzlOAPljR9j-menu-subitem-head {
       font-size: 9px;
       font-family: "Lucida Console", Monaco, monospace;
       font-weight: 600;
@@ -109,7 +109,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    .i8EK4UFXUqNxcNnZd-menu-subitem-body {
+    .imev8OqzlOAPljR9j-menu-subitem-body {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       margin-left: 7px;
@@ -117,28 +117,28 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    .i8EK4UFXUqNxcNnZd-labeled-input {
+    .imev8OqzlOAPljR9j-labeled-input {
       all: initial;
       display: flex;
       align-items: center;
       margin-top: 1px;
       margin-bottom: 1px;
     }
-    .i8EK4UFXUqNxcNnZd-label {
+    .imev8OqzlOAPljR9j-label {
       all: initial;
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
       cursor: pointer;
     }
-    .i8EK4UFXUqNxcNnZd-slider {
+    .imev8OqzlOAPljR9j-slider {
       width: 100%;
       margin-bottom: 2px;
     }
-    .i8EK4UFXUqNxcNnZd-slider::-moz-focus-outer {
+    .imev8OqzlOAPljR9j-slider::-moz-focus-outer {
       border: 0;
     }
-    .i8EK4UFXUqNxcNnZd-slider-text-left {
+    .imev8OqzlOAPljR9j-slider-text-left {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       font-style: italic;
@@ -146,20 +146,20 @@
       float: left;
       margin-top: 2px;
     }
-    .i8EK4UFXUqNxcNnZd-slider-text-right {
+    .imev8OqzlOAPljR9j-slider-text-right {
       font-size: 8px;
       font-family: "Lucida Console", Monaco, monospace;
       color: black;
       float: right;
     }
-    .i8EK4UFXUqNxcNnZd-checkbox {
+    .imev8OqzlOAPljR9j-checkbox {
       margin-left: 0px !important;
       margin-right: 4px !important;
       margin-top: 2px !important;
       margin-bottom: 2px !important;
       padding: 0px !important;
     }
-    .i8EK4UFXUqNxcNnZd-select {
+    .imev8OqzlOAPljR9j-select {
       cursor: pointer;
       outline: none;
       font-size: 8px;
@@ -188,15 +188,15 @@
     }
     @-moz-document url-prefix() {
       /* Dirty hack to remove dotted border on focus */
-      .i8EK4UFXUqNxcNnZd-select {
+      .imev8OqzlOAPljR9j-select {
         color: transparent !important;
         text-shadow: 0 0 0 black !important;
       }
     }
-    .i8EK4UFXUqNxcNnZd-select:after {
+    .imev8OqzlOAPljR9j-select:after {
       cursor: pointer;
     }
-    .i8EK4UFXUqNxcNnZd-button {
+    .imev8OqzlOAPljR9j-button {
       cursor: pointer;
       outline: none;
       font-size: 8px;
@@ -213,29 +213,29 @@
       border: 1.2px solid #bbb;
       box-shadow: 0 1px 0 1px rgba(0, 0, 0, 0.04);
     }
-    .i8EK4UFXUqNxcNnZd-button:hover {
+    .imev8OqzlOAPljR9j-button:hover {
       border: 1.2px solid #999;
       background-color: #f2f2f2;
     }
-    .i8EK4UFXUqNxcNnZd-button:active {
+    .imev8OqzlOAPljR9j-button:active {
       background-color: #ddd;
     }
-    .i8EK4UFXUqNxcNnZd-button::-moz-focus-inner {
+    .imev8OqzlOAPljR9j-button::-moz-focus-inner {
       border: 0;
     }
     /* Hidden menu items */
-    #i8EK4UFXUqNxcNnZd-graph-select-div {
+    #imev8OqzlOAPljR9j-graph-select-div {
       display: none;
     }
-    #i8EK4UFXUqNxcNnZd-node-size-norm-div {
+    #imev8OqzlOAPljR9j-node-size-norm-div {
       display: none;
     }
-    #i8EK4UFXUqNxcNnZd-edge-size-norm-div {
+    #imev8OqzlOAPljR9j-edge-size-norm-div {
       display: none;
     }
 
     /* Graph */
-    #i8EK4UFXUqNxcNnZd-tooltip-div {
+    #imev8OqzlOAPljR9j-tooltip-div {
       font-size: 10px;
       font-family: "Lucida Console", Monaco, monospace;
       z-index: 42001;
@@ -254,7 +254,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-menu-toggle-button, #i8EK4UFXUqNxcNnZd-details-toggle-button, #i8EK4UFXUqNxcNnZd-progress-container {
+    #imev8OqzlOAPljR9j-menu-toggle-button, #imev8OqzlOAPljR9j-details-toggle-button, #imev8OqzlOAPljR9j-progress-container {
       font-size: 14px;
       font-family: "Lucida Console", Monaco, monospace;
       z-index: 42000;
@@ -266,7 +266,7 @@
       line-height: normal;
       box-sizing: content-box;
     }
-    #i8EK4UFXUqNxcNnZd-menu-toggle-button {
+    #imev8OqzlOAPljR9j-menu-toggle-button {
       top: 0;
       right: 0;
       padding-left: 6px;
@@ -278,7 +278,7 @@
       border-bottom: 1px solid #ccc;
       border-left: 1px solid #ccc;
     }
-    #i8EK4UFXUqNxcNnZd-details-toggle-button {
+    #imev8OqzlOAPljR9j-details-toggle-button {
       bottom: 0;
       left: 0;
       padding-left: 19px;
@@ -290,7 +290,7 @@
       border-bottom: 0px;
       border-left: 0px;
     }
-    #i8EK4UFXUqNxcNnZd-progress-container {
+    #imev8OqzlOAPljR9j-progress-container {
       font-size: 10px;
       text-align: center;
       top: 46%;
@@ -302,7 +302,7 @@
     }
 
     /* Details */
-    #i8EK4UFXUqNxcNnZd-details-user-provided {
+    #imev8OqzlOAPljR9j-details-user-provided {
       margin-top: 3px;
       padding-top: 3.5px;
       border-top: 0.5px dashed black;
@@ -311,578 +311,578 @@
       white-space: pre-wrap;
       word-break: break-word;
     }
-    #i8EK4UFXUqNxcNnZd-details-user-provided ul {
+    #imev8OqzlOAPljR9j-details-user-provided ul {
       list-style-position: inside;
       padding-left: 6px;
     }
   </style>
 
-  <div id="i8EK4UFXUqNxcNnZd-main-div">
-    <div id="i8EK4UFXUqNxcNnZd-tooltip-div"></div>
+  <div id="imev8OqzlOAPljR9j-main-div">
+    <div id="imev8OqzlOAPljR9j-tooltip-div"></div>
 
-    <div id="i8EK4UFXUqNxcNnZd-left-div">
-      <div id="i8EK4UFXUqNxcNnZd-left-inner-div">
-        <div id="i8EK4UFXUqNxcNnZd-graph-div"></div>
-        <div id="i8EK4UFXUqNxcNnZd-details-div">
-          <div id="i8EK4UFXUqNxcNnZd-details-head">
+    <div id="imev8OqzlOAPljR9j-left-div">
+      <div id="imev8OqzlOAPljR9j-left-inner-div">
+        <div id="imev8OqzlOAPljR9j-graph-div"></div>
+        <div id="imev8OqzlOAPljR9j-details-div">
+          <div id="imev8OqzlOAPljR9j-details-head">
             Details for selected element
           </div>
-          <div id="i8EK4UFXUqNxcNnZd-details-body">
+          <div id="imev8OqzlOAPljR9j-details-body">
           </div>
         </div>
       </div>
     </div>
 
-    <div id="i8EK4UFXUqNxcNnZd-right-div">
-      <div id="i8EK4UFXUqNxcNnZd-right-inner-div">
+    <div id="imev8OqzlOAPljR9j-right-div">
+      <div id="imev8OqzlOAPljR9j-right-inner-div">
         <!-- Menu: General -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-general-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-general-head">
           General
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-general-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-general-body">
           <!-- Sub-menu: State -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               App state
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-reset"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-reset"
                       type="button">Reset</button>
             </div>
           </div>
           <!-- Sub-menu: Display mode (fullscreen or not) -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Display mode
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-fullscreen-button"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-fullscreen-button"
                       type="button">Enter full screen</button>
             </div>
           </div>
           <!-- Sub-menu: Export -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Export
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-svg"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-svg"
                       type="button">SVG</button>
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-png"
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-png"
                       type="button">PNG</button>
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-jpg"
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-jpg"
                       type="button">JPG</button>
             </div>
           </div>
         </div>
         <!-- Menu: Data -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-data-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-data-head">
           Data selection
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-data-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-data-body">
           <!-- Sub-menu: Graph (only shown if multiple graphs in data) -->
-          <div id="i8EK4UFXUqNxcNnZd-graph-select-div">
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+          <div id="imev8OqzlOAPljR9j-graph-select-div">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Graph
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <select class="i8EK4UFXUqNxcNnZd-select"
-                      id="i8EK4UFXUqNxcNnZd-graph-select"></select>
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <select class="imev8OqzlOAPljR9j-select"
+                      id="imev8OqzlOAPljR9j-graph-select"></select>
             </div>
           </div>
           <!-- Sub-menu: Node label text -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Node label text
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <select class="i8EK4UFXUqNxcNnZd-select"
-                      id="i8EK4UFXUqNxcNnZd-node-label-data-source-select"></select>
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <select class="imev8OqzlOAPljR9j-select"
+                      id="imev8OqzlOAPljR9j-node-label-data-source-select"></select>
             </div>
           </div>
           <!-- Sub-menu: Edge label text -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Edge label text
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <select class="i8EK4UFXUqNxcNnZd-select"
-                      id="i8EK4UFXUqNxcNnZd-edge-label-data-source-select"></select>
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <select class="imev8OqzlOAPljR9j-select"
+                      id="imev8OqzlOAPljR9j-edge-label-data-source-select"></select>
             </div>
           </div>
           <!-- Sub-menu: Node size -->
-          <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+          <div class="imev8OqzlOAPljR9j-menu-subitem-head">
             Node size
           </div>
-          <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
+          <div class="imev8OqzlOAPljR9j-menu-subitem-body">
             <div>
-              <select class="i8EK4UFXUqNxcNnZd-select"
-                      id="i8EK4UFXUqNxcNnZd-node-size-data-source-select"></select>
+              <select class="imev8OqzlOAPljR9j-select"
+                      id="imev8OqzlOAPljR9j-node-size-data-source-select"></select>
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-              <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                     id="i8EK4UFXUqNxcNnZd-node-size-normalization-checkbox"
+            <div class="imev8OqzlOAPljR9j-labeled-input">
+              <input class="imev8OqzlOAPljR9j-checkbox"
+                     id="imev8OqzlOAPljR9j-node-size-normalization-checkbox"
                      type="checkbox">
-              <label class="i8EK4UFXUqNxcNnZd-label"
-                     for="i8EK4UFXUqNxcNnZd-node-size-normalization-checkbox">Normalize</label>
+              <label class="imev8OqzlOAPljR9j-label"
+                     for="imev8OqzlOAPljR9j-node-size-normalization-checkbox">Normalize</label>
             </div>
-            <div id="i8EK4UFXUqNxcNnZd-node-size-norm-div">
+            <div id="imev8OqzlOAPljR9j-node-size-norm-div">
               <div>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Minimum</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-node-size-normalization-min-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-node-size-normalization-min-slider"
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Minimum</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-node-size-normalization-min-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-node-size-normalization-min-slider"
                        type="range" min="0.01" max="300.0" step="0.01">
               </div>
               <div>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Maximum</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-node-size-normalization-max-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-node-size-normalization-max-slider"
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Maximum</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-node-size-normalization-max-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-node-size-normalization-max-slider"
                        type="range" min="0.01" max="300.0" step="0.01">
               </div>
             </div>
           </div>
           <!-- Sub-menu: Edge size -->
-          <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+          <div class="imev8OqzlOAPljR9j-menu-subitem-head">
             Edge size
           </div>
-          <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
+          <div class="imev8OqzlOAPljR9j-menu-subitem-body">
             <div>
-              <select class="i8EK4UFXUqNxcNnZd-select"
-                      id="i8EK4UFXUqNxcNnZd-edge-size-data-source-select"></select>
+              <select class="imev8OqzlOAPljR9j-select"
+                      id="imev8OqzlOAPljR9j-edge-size-data-source-select"></select>
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-              <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                     id="i8EK4UFXUqNxcNnZd-edge-size-normalization-checkbox"
+            <div class="imev8OqzlOAPljR9j-labeled-input">
+              <input class="imev8OqzlOAPljR9j-checkbox"
+                     id="imev8OqzlOAPljR9j-edge-size-normalization-checkbox"
                      type="checkbox">
-              <label class="i8EK4UFXUqNxcNnZd-label"
-                     for="i8EK4UFXUqNxcNnZd-edge-size-normalization-checkbox">Normalize</label>
+              <label class="imev8OqzlOAPljR9j-label"
+                     for="imev8OqzlOAPljR9j-edge-size-normalization-checkbox">Normalize</label>
             </div>
-            <div id="i8EK4UFXUqNxcNnZd-edge-size-norm-div">
+            <div id="imev8OqzlOAPljR9j-edge-size-norm-div">
               <div>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Minimum</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-edge-size-normalization-min-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-edge-size-normalization-min-slider"
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Minimum</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-edge-size-normalization-min-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-edge-size-normalization-min-slider"
                        type="range" min="0.01" max="50.0" step="0.01">
               </div>
               <div>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Maximum</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-edge-size-normalization-max-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-edge-size-normalization-max-slider"
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Maximum</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-edge-size-normalization-max-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-edge-size-normalization-max-slider"
                        type="range" min="0.01" max="50.0" step="0.01">
               </div>
             </div>
           </div>
         </div>
         <!-- Menu: Nodes -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-node-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-node-head">
           Nodes
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-node-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-node-body">
           <!-- Sub-menu: Visibility -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Visibility
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-checkbox">Show nodes</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-checkbox">Show nodes</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Size -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Size
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
               <div>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Scaling factor</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-node-size-factor-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-node-size-factor-slider"
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Scaling factor</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-node-size-factor-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-node-size-factor-slider"
                        type="range" min="0.01" max="5.0" step="0.01">
               </div>
             </div>
           </div>
           <!-- Sub-menu: Position -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Position
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <button class="i8EK4UFXUqNxcNnZd-button"
-                      id="i8EK4UFXUqNxcNnZd-node-release-button"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <button class="imev8OqzlOAPljR9j-button"
+                      id="imev8OqzlOAPljR9j-node-release-button"
                       type="button">Release fixed nodes</button>
             </div>
           </div>
           <!-- Sub-menu: Drag behavior -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Drag behavior
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-drag-fix-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-drag-fix-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-drag-fix-checkbox">Fix node position</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-drag-fix-checkbox">Fix node position</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Hover behavior -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Hover behavior
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-hover-neighborhood-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-hover-neighborhood-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-hover-neighborhood-checkbox">Show neighborhood</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-hover-neighborhood-checkbox">Show neighborhood</label>
               </div>
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-hover-tooltip-checkbox"
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-hover-tooltip-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-hover-tooltip-checkbox">Show tooltips (if provided)</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-hover-tooltip-checkbox">Show tooltips (if provided)</label>
               </div>
             </div>
           </div>
         </div>
         <!-- Menu: Node images -->
-        <div id="i8EK4UFXUqNxcNnZd-node-image-meta-control">
-          <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-               id="i8EK4UFXUqNxcNnZd-node-image-head">
+        <div id="imev8OqzlOAPljR9j-node-image-meta-control">
+          <div class="imev8OqzlOAPljR9j-menu-item-head"
+               id="imev8OqzlOAPljR9j-node-image-head">
             Node images
           </div>
-          <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-               id="i8EK4UFXUqNxcNnZd-node-image-body">
+          <div class="imev8OqzlOAPljR9j-menu-item-body"
+               id="imev8OqzlOAPljR9j-node-image-body">
             <!-- Sub-menu: Visibility -->
             <div>
-              <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+              <div class="imev8OqzlOAPljR9j-menu-subitem-head">
                 Visibility
               </div>
-              <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-                <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                  <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                         id="i8EK4UFXUqNxcNnZd-node-image-checkbox"
+              <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+                <div class="imev8OqzlOAPljR9j-labeled-input">
+                  <input class="imev8OqzlOAPljR9j-checkbox"
+                         id="imev8OqzlOAPljR9j-node-image-checkbox"
                          type="checkbox">
-                  <label class="i8EK4UFXUqNxcNnZd-label"
-                         for="i8EK4UFXUqNxcNnZd-node-image-checkbox">Show node images</label>
+                  <label class="imev8OqzlOAPljR9j-label"
+                         for="imev8OqzlOAPljR9j-node-image-checkbox">Show node images</label>
                 </div>
               </div>
             </div>
             <!-- Sub-menu: Size -->
             <div>
-              <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+              <div class="imev8OqzlOAPljR9j-menu-subitem-head">
                 Size
               </div>
-              <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Scaling factor</span>
-                <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-node-image-size-factor-text"></span>
-                <input class="i8EK4UFXUqNxcNnZd-slider"
-                       id="i8EK4UFXUqNxcNnZd-node-image-size-factor-slider"
+              <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+                <span class="imev8OqzlOAPljR9j-slider-text-left">Scaling factor</span>
+                <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-node-image-size-factor-text"></span>
+                <input class="imev8OqzlOAPljR9j-slider"
+                       id="imev8OqzlOAPljR9j-node-image-size-factor-slider"
                        type="range" min="0.01" max="5.0" step="0.01">
               </div>
             </div>
           </div>
         </div>
         <!-- Menu: Node labels -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-node-label-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-node-label-head">
           Node labels
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-node-label-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-node-label-body">
           <!-- Sub-menu: Visibility -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Visibility
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-label-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-label-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-label-checkbox">Show node labels</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-label-checkbox">Show node labels</label>
               </div>
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-node-label-border-checkbox"
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-node-label-border-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-node-label-border-checkbox">Show borders</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-node-label-border-checkbox">Show borders</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Size -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Size
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Scaling factor</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                    id="i8EK4UFXUqNxcNnZd-node-label-size-factor-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-node-label-size-factor-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Scaling factor</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                    id="imev8OqzlOAPljR9j-node-label-size-factor-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-node-label-size-factor-slider"
                      type="range" min="0.01" max="5.0" step="0.01">
             </div>
           </div>
           <!-- Sub-menu: Rotation -->
-          <div id="i8EK4UFXUqNxcNnZd-node-label-rotation">
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+          <div id="imev8OqzlOAPljR9j-node-label-rotation">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Rotation
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Angle</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                    id="i8EK4UFXUqNxcNnZd-node-label-rotation-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-node-label-rotation-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Angle</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                    id="imev8OqzlOAPljR9j-node-label-rotation-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-node-label-rotation-slider"
                      type="range" min="0.0" max="359.0" step="1.0">
             </div>
           </div>
         </div>
         <!-- Menu: Edges -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-edge-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-edge-head">
           Edges
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-edge-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-edge-body">
           <!-- Sub-menu: Visibility -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Visibility
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-edge-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-edge-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-edge-checkbox">Show edges</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-edge-checkbox">Show edges</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Size -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Size
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Scaling factor</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                    id="i8EK4UFXUqNxcNnZd-edge-size-factor-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-edge-size-factor-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Scaling factor</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                    id="imev8OqzlOAPljR9j-edge-size-factor-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-edge-size-factor-slider"
                      type="range" min="0.01" max="5.0" step="0.01">
             </div>
           </div>
           <!-- Sub-menu: Form -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Form
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Curvature</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                    id="i8EK4UFXUqNxcNnZd-edge-curvature-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-edge-curvature-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Curvature</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                    id="imev8OqzlOAPljR9j-edge-curvature-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-edge-curvature-slider"
                      type="range" min="-1.2" max="1.2" step="0.02">
             </div>
           </div>
           <!-- Sub-menu: Hover behavior -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Hover behavior
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-edge-hover-tooltip-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-edge-hover-tooltip-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-edge-hover-tooltip-checkbox">Show tooltips (if provided)</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-edge-hover-tooltip-checkbox">Show tooltips (if provided)</label>
               </div>
             </div>
           </div>
         </div>
         <!-- Menu: Edge labels -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-edge-label-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-edge-label-head">
           Edge labels
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-edge-label-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-edge-label-body">
           <!-- Sub-menu: Visibility -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Visibility
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-edge-label-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-edge-label-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-edge-label-checkbox">Show edge labels</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-edge-label-checkbox">Show edge labels</label>
               </div>
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-edge-label-border-checkbox"
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-edge-label-border-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-edge-label-border-checkbox">Show borders</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-edge-label-border-checkbox">Show borders</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Size -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Size
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Scaling factor</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                    id="i8EK4UFXUqNxcNnZd-edge-label-size-factor-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-edge-label-size-factor-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Scaling factor</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                    id="imev8OqzlOAPljR9j-edge-label-size-factor-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-edge-label-size-factor-slider"
                      type="range" min="0.01" max="5.0" step="0.01">
             </div>
           </div>
           <!-- Sub-menu: Rotation -->
-          <div id="i8EK4UFXUqNxcNnZd-edge-label-rotation">
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+          <div id="imev8OqzlOAPljR9j-edge-label-rotation">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Rotation
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Angle</span>
-              <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                      id="i8EK4UFXUqNxcNnZd-edge-label-rotation-text"></span>
-              <input class="i8EK4UFXUqNxcNnZd-slider"
-                     id="i8EK4UFXUqNxcNnZd-edge-label-rotation-slider"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <span class="imev8OqzlOAPljR9j-slider-text-left">Angle</span>
+              <span class="imev8OqzlOAPljR9j-slider-text-right"
+                      id="imev8OqzlOAPljR9j-edge-label-rotation-text"></span>
+              <input class="imev8OqzlOAPljR9j-slider"
+                     id="imev8OqzlOAPljR9j-edge-label-rotation-slider"
                      type="range" min="0.0" max="359.0" step="1.0">
             </div>
           </div>
         </div>
         <!-- Menu: Layout algorithm -->
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-head"
-             id="i8EK4UFXUqNxcNnZd-layout-algorithm-head">
+        <div class="imev8OqzlOAPljR9j-menu-item-head"
+             id="imev8OqzlOAPljR9j-layout-algorithm-head">
           Layout algorithm
         </div>
-        <div class="i8EK4UFXUqNxcNnZd-menu-item-body"
-             id="i8EK4UFXUqNxcNnZd-layout-algorithm-body">
+        <div class="imev8OqzlOAPljR9j-menu-item-body"
+             id="imev8OqzlOAPljR9j-layout-algorithm-body">
 
           <!-- Sub-menu: Simulation -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Simulation
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-simulation-active-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-simulation-active-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-simulation-active-checkbox">Active</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-simulation-active-checkbox">Active</label>
               </div>
             </div>
           </div>
           <!-- Sub-menu: Many-body force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Many-body force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-many-body-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-many-body-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-many-body-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-many-body-force-checkbox">On</label>
               </div>
-              <div id="i8EK4UFXUqNxcNnZd-many-body-force-div">
+              <div id="imev8OqzlOAPljR9j-many-body-force-div">
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Strength</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-many-body-force-strength-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-many-body-force-strength-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Strength</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-many-body-force-strength-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-many-body-force-strength-slider"
                          type="range" min="-2000.0" max="200.0" step="0.01"
                          style="direction:rtl;">
                 </div>
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Theta</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-many-body-force-theta-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-many-body-force-theta-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Theta</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-many-body-force-theta-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-many-body-force-theta-slider"
                          type="range" min="0.01" max="2.0" step="0.001">
                 </div>
                 <div style="margin-top: 6px;">
-                  <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                    <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                         id="i8EK4UFXUqNxcNnZd-many-body-force-min-distance-checkbox"
+                  <div class="imev8OqzlOAPljR9j-labeled-input">
+                    <input class="imev8OqzlOAPljR9j-checkbox"
+                         id="imev8OqzlOAPljR9j-many-body-force-min-distance-checkbox"
                          type="checkbox">
-                    <label class="i8EK4UFXUqNxcNnZd-label"
-                           for="i8EK4UFXUqNxcNnZd-many-body-force-min-distance-checkbox">Use minimum distance</label>
+                    <label class="imev8OqzlOAPljR9j-label"
+                           for="imev8OqzlOAPljR9j-many-body-force-min-distance-checkbox">Use minimum distance</label>
                   </div>
-                  <div id="i8EK4UFXUqNxcNnZd-many-body-force-min-distance-div">
-                    <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Min</span>
-                    <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                          id="i8EK4UFXUqNxcNnZd-many-body-force-min-distance-text"></span>
-                    <input class="i8EK4UFXUqNxcNnZd-slider"
-                           id="i8EK4UFXUqNxcNnZd-many-body-force-min-distance-slider"
+                  <div id="imev8OqzlOAPljR9j-many-body-force-min-distance-div">
+                    <span class="imev8OqzlOAPljR9j-slider-text-left">Min</span>
+                    <span class="imev8OqzlOAPljR9j-slider-text-right"
+                          id="imev8OqzlOAPljR9j-many-body-force-min-distance-text"></span>
+                    <input class="imev8OqzlOAPljR9j-slider"
+                           id="imev8OqzlOAPljR9j-many-body-force-min-distance-slider"
                            type="range" min="0.01" max="10000.0" step="0.01">
                   </div>
                 </div>
                 <div style="margin-top: 6px;">
-                  <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                    <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                         id="i8EK4UFXUqNxcNnZd-many-body-force-max-distance-checkbox"
+                  <div class="imev8OqzlOAPljR9j-labeled-input">
+                    <input class="imev8OqzlOAPljR9j-checkbox"
+                         id="imev8OqzlOAPljR9j-many-body-force-max-distance-checkbox"
                          type="checkbox">
-                    <label class="i8EK4UFXUqNxcNnZd-label"
-                           for="i8EK4UFXUqNxcNnZd-many-body-force-max-distance-checkbox">Use maximum distance</label>
+                    <label class="imev8OqzlOAPljR9j-label"
+                           for="imev8OqzlOAPljR9j-many-body-force-max-distance-checkbox">Use maximum distance</label>
                   </div>
-                  <div id="i8EK4UFXUqNxcNnZd-many-body-force-max-distance-div">
-                    <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Max</span>
-                    <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                          id="i8EK4UFXUqNxcNnZd-many-body-force-max-distance-text"></span>
-                    <input class="i8EK4UFXUqNxcNnZd-slider"
-                           id="i8EK4UFXUqNxcNnZd-many-body-force-max-distance-slider"
+                  <div id="imev8OqzlOAPljR9j-many-body-force-max-distance-div">
+                    <span class="imev8OqzlOAPljR9j-slider-text-left">Max</span>
+                    <span class="imev8OqzlOAPljR9j-slider-text-right"
+                          id="imev8OqzlOAPljR9j-many-body-force-max-distance-text"></span>
+                    <input class="imev8OqzlOAPljR9j-slider"
+                           id="imev8OqzlOAPljR9j-many-body-force-max-distance-slider"
                            type="range" min="0.01" max="10000.0" step="0.01">
                   </div>
                 </div>
@@ -891,33 +891,33 @@
           </div>
           <!-- Sub-menu: Links force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Links force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-links-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-links-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-links-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-links-force-checkbox">On</label>
                 </label>
               </div>
-              <div id="i8EK4UFXUqNxcNnZd-links-force-div">
+              <div id="imev8OqzlOAPljR9j-links-force-div">
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Distance</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-links-force-distance-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-links-force-distance-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Distance</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-links-force-distance-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-links-force-distance-slider"
                          type="range" min="0.01" max="1000.0" step="0.01">
                 </div>
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Strength</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-links-force-strength-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-links-force-strength-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Strength</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-links-force-strength-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-links-force-strength-slider"
                          type="range" min="0.01" max="1.0" step="0.001">
                 </div>
               </div>
@@ -925,32 +925,32 @@
           </div>
           <!-- Sub-menu: Collision force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Collision force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-collision-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-collision-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-collision-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-collision-force-checkbox">On</label>
               </div>
-              <div id="i8EK4UFXUqNxcNnZd-collision-force-div">
+              <div id="imev8OqzlOAPljR9j-collision-force-div">
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Radius</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-collision-force-radius-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-collision-force-radius-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Radius</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-collision-force-radius-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-collision-force-radius-slider"
                          type="range" min="0" max="100.0" step="0.01">
                 </div>
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Strength</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-collision-force-strength-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-collision-force-strength-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Strength</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-collision-force-strength-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-collision-force-strength-slider"
                          type="range" min="0.01" max="1.0" step="0.001">
                 </div>
               </div>
@@ -958,24 +958,24 @@
           </div>
           <!-- Sub-menu: x-positioning force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               x-positioning force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-x-positioning-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-x-positioning-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-x-positioning-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-x-positioning-force-checkbox">On</label>
               </div>
-              <div id="i8EK4UFXUqNxcNnZd-x-positioning-force-div">
+              <div id="imev8OqzlOAPljR9j-x-positioning-force-div">
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Strength</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-x-positioning-force-strength-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-x-positioning-force-strength-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Strength</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-x-positioning-force-strength-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-x-positioning-force-strength-slider"
                          type="range" min="0.01" max="1.0" step="0.001">
                 </div>
               </div>
@@ -983,24 +983,24 @@
           </div>
           <!-- Sub-menu: y-positioning force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               y-positioning force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-y-positioning-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-y-positioning-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-y-positioning-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-y-positioning-force-checkbox">On</label>
               </div>
-              <div id="i8EK4UFXUqNxcNnZd-y-positioning-force-div">
+              <div id="imev8OqzlOAPljR9j-y-positioning-force-div">
                 <div>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-left">Strength</span>
-                  <span class="i8EK4UFXUqNxcNnZd-slider-text-right"
-                        id="i8EK4UFXUqNxcNnZd-y-positioning-force-strength-text"></span>
-                  <input class="i8EK4UFXUqNxcNnZd-slider"
-                         id="i8EK4UFXUqNxcNnZd-y-positioning-force-strength-slider"
+                  <span class="imev8OqzlOAPljR9j-slider-text-left">Strength</span>
+                  <span class="imev8OqzlOAPljR9j-slider-text-right"
+                        id="imev8OqzlOAPljR9j-y-positioning-force-strength-text"></span>
+                  <input class="imev8OqzlOAPljR9j-slider"
+                         id="imev8OqzlOAPljR9j-y-positioning-force-strength-slider"
                          type="range" min="0.01" max="1.0" step="0.001">
                 </div>
               </div>
@@ -1008,16 +1008,16 @@
           </div>
           <!-- Sub-menu: Centering force -->
           <div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-head">
+            <div class="imev8OqzlOAPljR9j-menu-subitem-head">
               Centering force
             </div>
-            <div class="i8EK4UFXUqNxcNnZd-menu-subitem-body">
-              <div class="i8EK4UFXUqNxcNnZd-labeled-input">
-                <input class="i8EK4UFXUqNxcNnZd-checkbox"
-                       id="i8EK4UFXUqNxcNnZd-centering-force-checkbox"
+            <div class="imev8OqzlOAPljR9j-menu-subitem-body">
+              <div class="imev8OqzlOAPljR9j-labeled-input">
+                <input class="imev8OqzlOAPljR9j-checkbox"
+                       id="imev8OqzlOAPljR9j-centering-force-checkbox"
                        type="checkbox">
-                <label class="i8EK4UFXUqNxcNnZd-label"
-                       for="i8EK4UFXUqNxcNnZd-centering-force-checkbox">On</label>
+                <label class="imev8OqzlOAPljR9j-label"
+                       for="imev8OqzlOAPljR9j-centering-force-checkbox">On</label>
               </div>
             </div>
           </div>
@@ -1070,7 +1070,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
 
           // 1) Fetch state.rawData
           fetchRawDataFromTemplating(){
-            state.rawData = [{"label": "Reference network for OTX2P1 and OTX2P2", "metadata": {"arrow_size": 15, "node_size": 15, "node_label_size": 20, "edge_size": 2}, "nodes": {"hgnc:33281": {"metadata": {"color": "#F8766D", "hover": "hgnc:33281\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"hgnc:33281\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": \"approved\",\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": null,\n  \"location_annotations\": [],\n  \"locations\": [],\n  \"aliases\": [],\n  \"previous_symbols\": [\n    \"OTX2P\"\n  ],\n  \"xrefs\": [\n    \"ncbigene:100033409\",\n    \"ensembl:ENSG00000234644\"\n  ],\n  \"associated_with\": [\n    \"refseq:NG_032194\",\n    \"vega:OTTHUMG00000020037\",\n    \"homeodb:8593\",\n    \"pseudogene.org:PGOHUM00000303938\"\n  ],\n  \"gene_type\": \"pseudogene\"\n}</p>"}}, "ncbigene:100033409": {"metadata": {"color": "#00BA38", "hover": "ncbigene:100033409\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ncbigene:100033409\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": \"-\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.nfBggPI8ffYAIbf7DKA8IcL95VNeUzQ6\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 75724170,\n      \"end\": 75724811\n    }\n  ],\n  \"aliases\": [\n    \"OTX2P\"\n  ],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:33281\"\n  ],\n  \"associated_with\": [],\n  \"gene_type\": \"pseudo\"\n}</p>"}}, "ensembl:ENSG00000234644": {"metadata": {"color": "#00B9E3", "hover": "ensembl:ENSG00000234644\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ensembl:ENSG00000234644\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": \"-\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL._CHxr4orI5x27KUc2VPGa0JnGJ0MEMms\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 75724221,\n      \"end\": 75724575\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:33281\"\n  ],\n  \"associated_with\": [],\n  \"gene_type\": \"processed_pseudogene\"\n}</p>"}}, "hgnc:54560": {"metadata": {"color": "#F8766D", "hover": "hgnc:54560\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"hgnc:54560\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": \"approved\",\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": null,\n  \"location_annotations\": [],\n  \"locations\": [],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"ncbigene:100419816\",\n    \"ensembl:ENSG00000227134\"\n  ],\n  \"associated_with\": [\n    \"refseq:NG_023739\"\n  ],\n  \"gene_type\": \"pseudogene\"\n}</p>"}}, "ensembl:ENSG00000227134": {"metadata": {"color": "#00BA38", "hover": "ensembl:ENSG00000227134\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ensembl:ENSG00000227134\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": \"+\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.JvQZZy4EBCYE2uCSnDfeOpAau8XfbIlq\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 146477426,\n      \"end\": 146478113\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:54560\"\n  ],\n  \"associated_with\": [],\n  \"gene_type\": \"processed_pseudogene\"\n}</p>"}}, "ncbigene:100419816": {"metadata": {"color": "#00B9E3", "hover": "ncbigene:100419816\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ncbigene:100419816\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": \"+\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.9zWoRFYc-hnhG5xUfCxB2hU_JTj3Bw3Z\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 146477354,\n      \"end\": 146478110\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"ensembl:ENSG00000227134\",\n    \"hgnc:54560\"\n  ],\n  \"associated_with\": [],\n  \"gene_type\": \"pseudo\"\n}</p>"}}}, "edges": [{"source": "hgnc:33281", "target": "ncbigene:100033409"}, {"source": "hgnc:33281", "target": "ensembl:ENSG00000234644"}, {"source": "ncbigene:100033409", "target": "hgnc:33281"}, {"source": "ensembl:ENSG00000234644", "target": "hgnc:33281"}, {"source": "hgnc:54560", "target": "ncbigene:100419816"}, {"source": "hgnc:54560", "target": "ensembl:ENSG00000227134"}, {"source": "ensembl:ENSG00000227134", "target": "hgnc:54560"}, {"source": "ncbigene:100419816", "target": "ensembl:ENSG00000227134"}, {"source": "ncbigene:100419816", "target": "hgnc:54560"}]}];
+            state.rawData = [{"label": "Reference network for OTX2P1 and OTX2P2", "metadata": {"arrow_size": 15, "node_size": 15, "node_label_size": 20, "edge_size": 2}, "nodes": {"hgnc:33281": {"metadata": {"color": "#F8766D", "hover": "hgnc:33281\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"hgnc:33281\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": \"approved\",\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": null,\n  \"location_annotations\": [],\n  \"locations\": [],\n  \"aliases\": [],\n  \"previous_symbols\": [\n    \"OTX2P\"\n  ],\n  \"xrefs\": [\n    \"vega:OTTHUMG00000020037\",\n    \"refseq:NG_032194\",\n    \"homeodb:8593\",\n    \"pseudogene.org:PGOHUM00000303938\",\n    \"ensembl:ENSG00000234644\",\n    \"ncbigene:100033409\"\n  ],\n  \"gene_type\": \"pseudogene\"\n}</p>"}}, "ensembl:ENSG00000234644": {"metadata": {"color": "#00BA38", "hover": "ensembl:ENSG00000234644\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ensembl:ENSG00000234644\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": \"-\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL._CHxr4orI5x27KUc2VPGa0JnGJ0MEMms\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 75724221,\n      \"end\": 75724575\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:33281\"\n  ],\n  \"gene_type\": \"processed_pseudogene\"\n}</p>"}}, "ncbigene:100033409": {"metadata": {"color": "#00B9E3", "hover": "ncbigene:100033409\nOTX2P1\n<i>OTX2 pseudogene 1</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ncbigene:100033409\",\n  \"symbol\": \"OTX2P1\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 1\",\n  \"strand\": \"-\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.nfBggPI8ffYAIbf7DKA8IcL95VNeUzQ6\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 75724170,\n      \"end\": 75724811\n    }\n  ],\n  \"aliases\": [\n    \"OTX2P\"\n  ],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:33281\"\n  ],\n  \"gene_type\": \"pseudo\"\n}</p>"}}, "hgnc:54560": {"metadata": {"color": "#F8766D", "hover": "hgnc:54560\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"hgnc:54560\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": \"approved\",\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": null,\n  \"location_annotations\": [],\n  \"locations\": [],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"refseq:NG_023739\",\n    \"ncbigene:100419816\",\n    \"ensembl:ENSG00000227134\"\n  ],\n  \"gene_type\": \"pseudogene\"\n}</p>"}}, "ncbigene:100419816": {"metadata": {"color": "#00BA38", "hover": "ncbigene:100419816\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ncbigene:100419816\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": \"+\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.9zWoRFYc-hnhG5xUfCxB2hU_JTj3Bw3Z\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 146477354,\n      \"end\": 146478110\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"ensembl:ENSG00000227134\",\n    \"hgnc:54560\"\n  ],\n  \"gene_type\": \"pseudo\"\n}</p>"}}, "ensembl:ENSG00000227134": {"metadata": {"color": "#00B9E3", "hover": "ensembl:ENSG00000227134\nOTX2P2\n<i>OTX2 pseudogene 2</i>", "click": "<p color='black'>{\n  \"concept_id\": \"ensembl:ENSG00000227134\",\n  \"symbol\": \"OTX2P2\",\n  \"symbol_status\": null,\n  \"label\": \"OTX2 pseudogene 2\",\n  \"strand\": \"+\",\n  \"location_annotations\": [],\n  \"locations\": [\n    {\n      \"id\": \"ga4gh:SL.JvQZZy4EBCYE2uCSnDfeOpAau8XfbIlq\",\n      \"label\": null,\n      \"description\": null,\n      \"extensions\": null,\n      \"digest\": null,\n      \"type\": \"SequenceLocation\",\n      \"sequenceReference\": {\n        \"id\": null,\n        \"label\": null,\n        \"description\": null,\n        \"extensions\": null,\n        \"digest\": null,\n        \"type\": \"SequenceReference\",\n        \"refgetAccession\": \"SQ.pnAqCRBrTsUoBghSD1yp_jXWSmlbdh4g\",\n        \"residueAlphabet\": null\n      },\n      \"start\": 146477426,\n      \"end\": 146478113\n    }\n  ],\n  \"aliases\": [],\n  \"previous_symbols\": [],\n  \"xrefs\": [\n    \"hgnc:54560\"\n  ],\n  \"gene_type\": \"processed_pseudogene\"\n}</p>"}}}, "edges": [{"source": "hgnc:33281", "target": "ensembl:ENSG00000234644"}, {"source": "hgnc:33281", "target": "ncbigene:100033409"}, {"source": "ensembl:ENSG00000234644", "target": "hgnc:33281"}, {"source": "ncbigene:100033409", "target": "hgnc:33281"}, {"source": "hgnc:54560", "target": "ncbigene:100419816"}, {"source": "hgnc:54560", "target": "ensembl:ENSG00000227134"}, {"source": "ncbigene:100419816", "target": "ensembl:ENSG00000227134"}, {"source": "ncbigene:100419816", "target": "hgnc:54560"}, {"source": "ensembl:ENSG00000227134", "target": "hgnc:54560"}]}];
             // Data selection and normalization
             state.nodeSizeDataSource = "size";
             state.useNodeSizeNormalization = false;
@@ -2000,126 +2000,126 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
 
         elements:{
           // Containers
-          mainContainer: document.getElementById("i8EK4UFXUqNxcNnZd-main-div"),
-          tooltipContainer: document.getElementById("i8EK4UFXUqNxcNnZd-tooltip-div"),
-          leftContainer: document.getElementById("i8EK4UFXUqNxcNnZd-left-div"),
-          rightContainer: document.getElementById("i8EK4UFXUqNxcNnZd-right-div"),
-          graphContainer: document.getElementById("i8EK4UFXUqNxcNnZd-graph-div"),
-          detailsContainer: document.getElementById("i8EK4UFXUqNxcNnZd-details-div"),
-          detailsHead: document.getElementById("i8EK4UFXUqNxcNnZd-details-head"),
-          detailsBody: document.getElementById("i8EK4UFXUqNxcNnZd-details-body"),
+          mainContainer: document.getElementById("imev8OqzlOAPljR9j-main-div"),
+          tooltipContainer: document.getElementById("imev8OqzlOAPljR9j-tooltip-div"),
+          leftContainer: document.getElementById("imev8OqzlOAPljR9j-left-div"),
+          rightContainer: document.getElementById("imev8OqzlOAPljR9j-right-div"),
+          graphContainer: document.getElementById("imev8OqzlOAPljR9j-graph-div"),
+          detailsContainer: document.getElementById("imev8OqzlOAPljR9j-details-div"),
+          detailsHead: document.getElementById("imev8OqzlOAPljR9j-details-head"),
+          detailsBody: document.getElementById("imev8OqzlOAPljR9j-details-body"),
           // Data sources
-          dataHead: document.getElementById("i8EK4UFXUqNxcNnZd-data-head"),
-          dataBody: document.getElementById("i8EK4UFXUqNxcNnZd-data-body"),
-          graphSelectionContainer: document.getElementById("i8EK4UFXUqNxcNnZd-graph-select-div"),
-          graphSelection: document.getElementById("i8EK4UFXUqNxcNnZd-graph-select"),
-          nodeSizeDataSourceSelect: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-data-source-select"),
-          nodeSizeNormalizationCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-normalization-checkbox"),
-          nodeSizeNormalizationContainer: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-norm-div"),
-          nodeSizeNormalizationMinText: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-normalization-min-text"),
-          nodeSizeNormalizationMinSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-normalization-min-slider"),
-          nodeSizeNormalizationMaxText: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-normalization-max-text"),
-          nodeSizeNormalizationMaxSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-normalization-max-slider"),
-          edgeSizeDataSourceSelect: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-data-source-select"),
-          edgeSizeNormalizationCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-normalization-checkbox"),
-          edgeSizeNormalizationContainer: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-norm-div"),
-          edgeSizeNormalizationMinText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-normalization-min-text"),
-          edgeSizeNormalizationMinSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-normalization-min-slider"),
-          edgeSizeNormalizationMaxText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-normalization-max-text"),
-          edgeSizeNormalizationMaxSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-normalization-max-slider"),
+          dataHead: document.getElementById("imev8OqzlOAPljR9j-data-head"),
+          dataBody: document.getElementById("imev8OqzlOAPljR9j-data-body"),
+          graphSelectionContainer: document.getElementById("imev8OqzlOAPljR9j-graph-select-div"),
+          graphSelection: document.getElementById("imev8OqzlOAPljR9j-graph-select"),
+          nodeSizeDataSourceSelect: document.getElementById("imev8OqzlOAPljR9j-node-size-data-source-select"),
+          nodeSizeNormalizationCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-size-normalization-checkbox"),
+          nodeSizeNormalizationContainer: document.getElementById("imev8OqzlOAPljR9j-node-size-norm-div"),
+          nodeSizeNormalizationMinText: document.getElementById("imev8OqzlOAPljR9j-node-size-normalization-min-text"),
+          nodeSizeNormalizationMinSlider: document.getElementById("imev8OqzlOAPljR9j-node-size-normalization-min-slider"),
+          nodeSizeNormalizationMaxText: document.getElementById("imev8OqzlOAPljR9j-node-size-normalization-max-text"),
+          nodeSizeNormalizationMaxSlider: document.getElementById("imev8OqzlOAPljR9j-node-size-normalization-max-slider"),
+          edgeSizeDataSourceSelect: document.getElementById("imev8OqzlOAPljR9j-edge-size-data-source-select"),
+          edgeSizeNormalizationCheckbox: document.getElementById("imev8OqzlOAPljR9j-edge-size-normalization-checkbox"),
+          edgeSizeNormalizationContainer: document.getElementById("imev8OqzlOAPljR9j-edge-size-norm-div"),
+          edgeSizeNormalizationMinText: document.getElementById("imev8OqzlOAPljR9j-edge-size-normalization-min-text"),
+          edgeSizeNormalizationMinSlider: document.getElementById("imev8OqzlOAPljR9j-edge-size-normalization-min-slider"),
+          edgeSizeNormalizationMaxText: document.getElementById("imev8OqzlOAPljR9j-edge-size-normalization-max-text"),
+          edgeSizeNormalizationMaxSlider: document.getElementById("imev8OqzlOAPljR9j-edge-size-normalization-max-slider"),
           // General
-          generalHead: document.getElementById("i8EK4UFXUqNxcNnZd-general-head"),
-          generalBody: document.getElementById("i8EK4UFXUqNxcNnZd-general-body"),
-          resetButton: document.getElementById("i8EK4UFXUqNxcNnZd-reset"),
-          fullscreenButton: document.getElementById("i8EK4UFXUqNxcNnZd-fullscreen-button"),
-          svgExportButton: document.getElementById("i8EK4UFXUqNxcNnZd-svg"),
-          pngExportButton: document.getElementById("i8EK4UFXUqNxcNnZd-png"),
-          jpgExportButton: document.getElementById("i8EK4UFXUqNxcNnZd-jpg"),
+          generalHead: document.getElementById("imev8OqzlOAPljR9j-general-head"),
+          generalBody: document.getElementById("imev8OqzlOAPljR9j-general-body"),
+          resetButton: document.getElementById("imev8OqzlOAPljR9j-reset"),
+          fullscreenButton: document.getElementById("imev8OqzlOAPljR9j-fullscreen-button"),
+          svgExportButton: document.getElementById("imev8OqzlOAPljR9j-svg"),
+          pngExportButton: document.getElementById("imev8OqzlOAPljR9j-png"),
+          jpgExportButton: document.getElementById("imev8OqzlOAPljR9j-jpg"),
           // Nodes
-          nodeHead: document.getElementById("i8EK4UFXUqNxcNnZd-node-head"),
-          nodeBody: document.getElementById("i8EK4UFXUqNxcNnZd-node-body"),
-          nodeCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-checkbox"),
-          nodeSizeFactorText: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-factor-text"),
-          nodeSizeFactorSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-size-factor-slider"),
-          nodeDragFixCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-drag-fix-checkbox"),
-          nodeHoverNeighborhoodCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-hover-neighborhood-checkbox"),
-          nodeHoverTooltipCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-hover-tooltip-checkbox"),
-          nodeReleaseButton: document.getElementById("i8EK4UFXUqNxcNnZd-node-release-button"),
+          nodeHead: document.getElementById("imev8OqzlOAPljR9j-node-head"),
+          nodeBody: document.getElementById("imev8OqzlOAPljR9j-node-body"),
+          nodeCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-checkbox"),
+          nodeSizeFactorText: document.getElementById("imev8OqzlOAPljR9j-node-size-factor-text"),
+          nodeSizeFactorSlider: document.getElementById("imev8OqzlOAPljR9j-node-size-factor-slider"),
+          nodeDragFixCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-drag-fix-checkbox"),
+          nodeHoverNeighborhoodCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-hover-neighborhood-checkbox"),
+          nodeHoverTooltipCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-hover-tooltip-checkbox"),
+          nodeReleaseButton: document.getElementById("imev8OqzlOAPljR9j-node-release-button"),
           // Node images
-          nodeImageHead: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-head"),
-          nodeImageBody: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-body"),
-          nodeImageCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-checkbox"),
-          nodeImageMetaControl: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-meta-control"),
-          nodeImageSizeFactorText: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-size-factor-text"),
-          nodeImageSizeFactorSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-image-size-factor-slider"),
+          nodeImageHead: document.getElementById("imev8OqzlOAPljR9j-node-image-head"),
+          nodeImageBody: document.getElementById("imev8OqzlOAPljR9j-node-image-body"),
+          nodeImageCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-image-checkbox"),
+          nodeImageMetaControl: document.getElementById("imev8OqzlOAPljR9j-node-image-meta-control"),
+          nodeImageSizeFactorText: document.getElementById("imev8OqzlOAPljR9j-node-image-size-factor-text"),
+          nodeImageSizeFactorSlider: document.getElementById("imev8OqzlOAPljR9j-node-image-size-factor-slider"),
           // Node labels
-          nodeLabelHead: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-head"),
-          nodeLabelBody: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-body"),
-          nodeLabelCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-checkbox"),
-          nodeLabelBorderCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-border-checkbox"),
-          nodeLabelTextDataSourceSelect: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-data-source-select"),
-          nodeLabelSizeFactorText: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-size-factor-text"),
-          nodeLabelSizeFactorSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-size-factor-slider"),
-          nodeLabelRotationText: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-rotation-text"),
-          nodeLabelRotationSlider: document.getElementById("i8EK4UFXUqNxcNnZd-node-label-rotation-slider"),
+          nodeLabelHead: document.getElementById("imev8OqzlOAPljR9j-node-label-head"),
+          nodeLabelBody: document.getElementById("imev8OqzlOAPljR9j-node-label-body"),
+          nodeLabelCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-label-checkbox"),
+          nodeLabelBorderCheckbox: document.getElementById("imev8OqzlOAPljR9j-node-label-border-checkbox"),
+          nodeLabelTextDataSourceSelect: document.getElementById("imev8OqzlOAPljR9j-node-label-data-source-select"),
+          nodeLabelSizeFactorText: document.getElementById("imev8OqzlOAPljR9j-node-label-size-factor-text"),
+          nodeLabelSizeFactorSlider: document.getElementById("imev8OqzlOAPljR9j-node-label-size-factor-slider"),
+          nodeLabelRotationText: document.getElementById("imev8OqzlOAPljR9j-node-label-rotation-text"),
+          nodeLabelRotationSlider: document.getElementById("imev8OqzlOAPljR9j-node-label-rotation-slider"),
           // Edges
-          edgeHead: document.getElementById("i8EK4UFXUqNxcNnZd-edge-head"),
-          edgeBody: document.getElementById("i8EK4UFXUqNxcNnZd-edge-body"),
-          edgeCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-edge-checkbox"),
-          edgeSizeFactorText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-factor-text"),
-          edgeSizeFactorSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-size-factor-slider"),
-          edgeCurvatureText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-curvature-text"),
-          edgeCurvatureSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-curvature-slider"),
-          edgeHoverTooltipCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-edge-hover-tooltip-checkbox"),
+          edgeHead: document.getElementById("imev8OqzlOAPljR9j-edge-head"),
+          edgeBody: document.getElementById("imev8OqzlOAPljR9j-edge-body"),
+          edgeCheckbox: document.getElementById("imev8OqzlOAPljR9j-edge-checkbox"),
+          edgeSizeFactorText: document.getElementById("imev8OqzlOAPljR9j-edge-size-factor-text"),
+          edgeSizeFactorSlider: document.getElementById("imev8OqzlOAPljR9j-edge-size-factor-slider"),
+          edgeCurvatureText: document.getElementById("imev8OqzlOAPljR9j-edge-curvature-text"),
+          edgeCurvatureSlider: document.getElementById("imev8OqzlOAPljR9j-edge-curvature-slider"),
+          edgeHoverTooltipCheckbox: document.getElementById("imev8OqzlOAPljR9j-edge-hover-tooltip-checkbox"),
           // Edge labels
-          edgeLabelHead: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-head"),
-          edgeLabelBody: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-body"),
-          edgeLabelCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-checkbox"),
-          edgeLabelBorderCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-border-checkbox"),
-          edgeLabelTextDataSourceSelect: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-data-source-select"),
-          edgeLabelSizeFactorText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-size-factor-text"),
-          edgeLabelSizeFactorSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-size-factor-slider"),
-          edgeLabelRotationText: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-rotation-text"),
-          edgeLabelRotationSlider: document.getElementById("i8EK4UFXUqNxcNnZd-edge-label-rotation-slider"),
+          edgeLabelHead: document.getElementById("imev8OqzlOAPljR9j-edge-label-head"),
+          edgeLabelBody: document.getElementById("imev8OqzlOAPljR9j-edge-label-body"),
+          edgeLabelCheckbox: document.getElementById("imev8OqzlOAPljR9j-edge-label-checkbox"),
+          edgeLabelBorderCheckbox: document.getElementById("imev8OqzlOAPljR9j-edge-label-border-checkbox"),
+          edgeLabelTextDataSourceSelect: document.getElementById("imev8OqzlOAPljR9j-edge-label-data-source-select"),
+          edgeLabelSizeFactorText: document.getElementById("imev8OqzlOAPljR9j-edge-label-size-factor-text"),
+          edgeLabelSizeFactorSlider: document.getElementById("imev8OqzlOAPljR9j-edge-label-size-factor-slider"),
+          edgeLabelRotationText: document.getElementById("imev8OqzlOAPljR9j-edge-label-rotation-text"),
+          edgeLabelRotationSlider: document.getElementById("imev8OqzlOAPljR9j-edge-label-rotation-slider"),
           // Layout algorithm
-          layoutAlgorithmHead: document.getElementById("i8EK4UFXUqNxcNnZd-layout-algorithm-head"),
-          layoutAlgorithmBody: document.getElementById("i8EK4UFXUqNxcNnZd-layout-algorithm-body"),
-          simulationCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-simulation-active-checkbox"),
-          manyBodyForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-checkbox"),
-          manyBodyForceContainer: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-div"),
-          manyBodyForceStrengthText: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-strength-text"),
-          manyBodyForceStrengthSlider: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-strength-slider"),
-          manyBodyForceThetaText: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-theta-text"),
-          manyBodyForceThetaSlider: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-theta-slider"),
-          manyBodyForceMinDistCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-min-distance-checkbox"),
-          manyBodyForceMinDistContainer: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-min-distance-div"),
-          manyBodyForceMinDistText: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-min-distance-text"),
-          manyBodyForceMinDistSlider: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-min-distance-slider"),
-          manyBodyForceMaxDistCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-max-distance-checkbox"),
-          manyBodyForceMaxDistContainer: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-max-distance-div"),
-          manyBodyForceMaxDistText: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-max-distance-text"),
-          manyBodyForceMaxDistSlider: document.getElementById("i8EK4UFXUqNxcNnZd-many-body-force-max-distance-slider"),
-          linksForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-checkbox"),
-          linksForceContainer: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-div"),
-          linksForceDistanceText: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-distance-text"),
-          linksForceDistanceSlider: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-distance-slider"),
-          linksForceStrengthText: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-strength-text"),
-          linksForceStrengthSlider: document.getElementById("i8EK4UFXUqNxcNnZd-links-force-strength-slider"),
-          collisionForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-checkbox"),
-          collisionForceContainer: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-div"),
-          collisionForceRadiusText: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-radius-text"),
-          collisionForceRadiusSlider: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-radius-slider"),
-          collisionForceStrengthText: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-strength-text"),
-          collisionForceStrengthSlider: document.getElementById("i8EK4UFXUqNxcNnZd-collision-force-strength-slider"),
-          xPositioningForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-x-positioning-force-checkbox"),
-          xPositioningForceContainer: document.getElementById("i8EK4UFXUqNxcNnZd-x-positioning-force-div"),
-          xPositioningForceStrengthText: document.getElementById("i8EK4UFXUqNxcNnZd-x-positioning-force-strength-text"),
-          xPositioningForceStrengthSlider: document.getElementById("i8EK4UFXUqNxcNnZd-x-positioning-force-strength-slider"),
-          yPositioningForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-y-positioning-force-checkbox"),
-          yPositioningForceContainer: document.getElementById("i8EK4UFXUqNxcNnZd-y-positioning-force-div"),
-          yPositioningForceStrengthText: document.getElementById("i8EK4UFXUqNxcNnZd-y-positioning-force-strength-text"),
-          yPositioningForceStrengthSlider: document.getElementById("i8EK4UFXUqNxcNnZd-y-positioning-force-strength-slider"),
-          centeringForceCheckbox: document.getElementById("i8EK4UFXUqNxcNnZd-centering-force-checkbox"),
+          layoutAlgorithmHead: document.getElementById("imev8OqzlOAPljR9j-layout-algorithm-head"),
+          layoutAlgorithmBody: document.getElementById("imev8OqzlOAPljR9j-layout-algorithm-body"),
+          simulationCheckbox: document.getElementById("imev8OqzlOAPljR9j-simulation-active-checkbox"),
+          manyBodyForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-many-body-force-checkbox"),
+          manyBodyForceContainer: document.getElementById("imev8OqzlOAPljR9j-many-body-force-div"),
+          manyBodyForceStrengthText: document.getElementById("imev8OqzlOAPljR9j-many-body-force-strength-text"),
+          manyBodyForceStrengthSlider: document.getElementById("imev8OqzlOAPljR9j-many-body-force-strength-slider"),
+          manyBodyForceThetaText: document.getElementById("imev8OqzlOAPljR9j-many-body-force-theta-text"),
+          manyBodyForceThetaSlider: document.getElementById("imev8OqzlOAPljR9j-many-body-force-theta-slider"),
+          manyBodyForceMinDistCheckbox: document.getElementById("imev8OqzlOAPljR9j-many-body-force-min-distance-checkbox"),
+          manyBodyForceMinDistContainer: document.getElementById("imev8OqzlOAPljR9j-many-body-force-min-distance-div"),
+          manyBodyForceMinDistText: document.getElementById("imev8OqzlOAPljR9j-many-body-force-min-distance-text"),
+          manyBodyForceMinDistSlider: document.getElementById("imev8OqzlOAPljR9j-many-body-force-min-distance-slider"),
+          manyBodyForceMaxDistCheckbox: document.getElementById("imev8OqzlOAPljR9j-many-body-force-max-distance-checkbox"),
+          manyBodyForceMaxDistContainer: document.getElementById("imev8OqzlOAPljR9j-many-body-force-max-distance-div"),
+          manyBodyForceMaxDistText: document.getElementById("imev8OqzlOAPljR9j-many-body-force-max-distance-text"),
+          manyBodyForceMaxDistSlider: document.getElementById("imev8OqzlOAPljR9j-many-body-force-max-distance-slider"),
+          linksForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-links-force-checkbox"),
+          linksForceContainer: document.getElementById("imev8OqzlOAPljR9j-links-force-div"),
+          linksForceDistanceText: document.getElementById("imev8OqzlOAPljR9j-links-force-distance-text"),
+          linksForceDistanceSlider: document.getElementById("imev8OqzlOAPljR9j-links-force-distance-slider"),
+          linksForceStrengthText: document.getElementById("imev8OqzlOAPljR9j-links-force-strength-text"),
+          linksForceStrengthSlider: document.getElementById("imev8OqzlOAPljR9j-links-force-strength-slider"),
+          collisionForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-collision-force-checkbox"),
+          collisionForceContainer: document.getElementById("imev8OqzlOAPljR9j-collision-force-div"),
+          collisionForceRadiusText: document.getElementById("imev8OqzlOAPljR9j-collision-force-radius-text"),
+          collisionForceRadiusSlider: document.getElementById("imev8OqzlOAPljR9j-collision-force-radius-slider"),
+          collisionForceStrengthText: document.getElementById("imev8OqzlOAPljR9j-collision-force-strength-text"),
+          collisionForceStrengthSlider: document.getElementById("imev8OqzlOAPljR9j-collision-force-strength-slider"),
+          xPositioningForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-x-positioning-force-checkbox"),
+          xPositioningForceContainer: document.getElementById("imev8OqzlOAPljR9j-x-positioning-force-div"),
+          xPositioningForceStrengthText: document.getElementById("imev8OqzlOAPljR9j-x-positioning-force-strength-text"),
+          xPositioningForceStrengthSlider: document.getElementById("imev8OqzlOAPljR9j-x-positioning-force-strength-slider"),
+          yPositioningForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-y-positioning-force-checkbox"),
+          yPositioningForceContainer: document.getElementById("imev8OqzlOAPljR9j-y-positioning-force-div"),
+          yPositioningForceStrengthText: document.getElementById("imev8OqzlOAPljR9j-y-positioning-force-strength-text"),
+          yPositioningForceStrengthSlider: document.getElementById("imev8OqzlOAPljR9j-y-positioning-force-strength-slider"),
+          centeringForceCheckbox: document.getElementById("imev8OqzlOAPljR9j-centering-force-checkbox"),
         },
 
         composites:{
@@ -2481,7 +2481,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
             create(){
               // Main container
               this.mainContainer = document.createElement("div");
-              this.mainContainer.id = "i8EK4UFXUqNxcNnZd-progress-container";
+              this.mainContainer.id = "imev8OqzlOAPljR9j-progress-container";
               this.mainContainer.style.backgroundColor = state.shownData.general.background_color;
               ui.elements.graphContainer.style.backgroundColor = state.shownData.general.background_color;
               // Text container
@@ -2530,7 +2530,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 } else {
                   menuDiv.innerText = ui.symbols.menuHidden;
                 }
-                menuDiv.id = "i8EK4UFXUqNxcNnZd-menu-toggle-button";
+                menuDiv.id = "imev8OqzlOAPljR9j-menu-toggle-button";
                 menuDiv.onclick = ui.composites.menu.toggle;
                 ui.elements.graphContainer.appendChild(menuDiv);
                 ui.elements.menuToggleDiv = menuDiv;
@@ -2544,27 +2544,27 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 } else {
                   detailsDiv.innerText = ui.symbols.detailsHidden;
                 }
-                detailsDiv.id = "i8EK4UFXUqNxcNnZd-details-toggle-button";
+                detailsDiv.id = "imev8OqzlOAPljR9j-details-toggle-button";
                 detailsDiv.onclick = ui.composites.details.toggle;
                 ui.elements.graphContainer.appendChild(detailsDiv);
                 ui.elements.detailsToggleDiv = detailsDiv;
               }
 
               // - Graph drawing area
-              const svg = d3.select("#i8EK4UFXUqNxcNnZd-graph-div").append("svg");
+              const svg = d3.select("#imev8OqzlOAPljR9j-graph-div").append("svg");
               state.currentGraphParts.svg = svg;
               svg
                 .attr("width", state.graphContainerWidth)
                 .attr("height", state.graphContainerHeight);
               // - Background rectangle
               const backgroundRect = svg.append("rect")
-                .attr("id", "i8EK4UFXUqNxcNnZd-background")
+                .attr("id", "imev8OqzlOAPljR9j-background")
                 .attr("width", state.graphContainerWidth)
                 .attr("height", state.graphContainerHeight)
                 .attr("fill", state.shownData.general.background_color);
               state.currentGraphParts.backgroundRect = backgroundRect;
               // - Zoomable and draggable group as graph drawing area
-              const view = svg.append("g").attr("id", "i8EK4UFXUqNxcNnZd-zoomable-graph-group");
+              const view = svg.append("g").attr("id", "imev8OqzlOAPljR9j-zoomable-graph-group");
               state.currentGraphParts.view = view;
               function zoomed(event) {
                 view.attr("transform", event.transform);
@@ -2623,7 +2623,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
               //       in back and which are drawn in front (there is no z-order property in SVG)
               // Edges
               state.currentGraphParts.edgeMainGroup = view.append("g")
-                .attr("id", "i8EK4UFXUqNxcNnZd-edge-group")
+                .attr("id", "imev8OqzlOAPljR9j-edge-group")
                 .style("display", ui.convert.boolToDisplayStyle(state.showEdges));
               state.currentGraphParts.edgeGroups = state.currentGraphParts.edgeMainGroup
                 .selectAll("g")
@@ -2631,7 +2631,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 .join("g");
               // Nodes
               state.currentGraphParts.nodeMainGroup = view.append("g")
-                .attr("id", "i8EK4UFXUqNxcNnZd-node-group")
+                .attr("id", "imev8OqzlOAPljR9j-node-group")
                 .style("display", ui.convert.boolToDisplayStyle(state.showNodes));
               state.currentGraphParts.nodeGroups = state.currentGraphParts.nodeMainGroup
                 .selectAll("g")
@@ -2643,7 +2643,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 edgeLabelData.push(i);
               }
               state.currentGraphParts.edgeLabelMainGroup = view.append("g")
-                .attr("id", "i8EK4UFXUqNxcNnZd-edge-label-group")
+                .attr("id", "imev8OqzlOAPljR9j-edge-label-group")
                 .style("display", ui.convert.boolToDisplayStyle(state.showEdgeLabels));
               state.currentGraphParts.edgeLabelGroups = state.currentGraphParts.edgeLabelMainGroup
                 .selectAll("g")
@@ -2655,7 +2655,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 nodeLabelData.push(i);
               }
               state.currentGraphParts.nodeLabelMainGroup = view.append("g")
-                .attr("id", "i8EK4UFXUqNxcNnZd-node-label-group");
+                .attr("id", "imev8OqzlOAPljR9j-node-label-group");
               state.currentGraphParts.nodeLabelGroups = state.currentGraphParts.nodeLabelMainGroup
                 .style("display", ui.convert.boolToDisplayStyle(state.showNodeLabels))
                 .selectAll("g")
@@ -2672,7 +2672,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 }
               }
               state.currentGraphParts.nodeImageMainGroup = view.append("g")
-                .attr("id", "i8EK4UFXUqNxcNnZd-node-image-group")
+                .attr("id", "imev8OqzlOAPljR9j-node-image-group")
                 .style("display", ui.convert.boolToDisplayStyle(state.showNodeImages));
               state.currentGraphParts.nodeImageGroups = state.currentGraphParts.nodeImageMainGroup
                 .selectAll("g")
@@ -2903,7 +2903,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
               function nodeClicked(event, node){
                 let htmlText = "<div>Node: " + String(node.id) + "</div>";
                 if(typeof(node.click) !== "undefined" && node.click !== ""){
-                  htmlText += '<div id="i8EK4UFXUqNxcNnZd-details-user-provided">' + node.click + '</div>';
+                  htmlText += '<div id="imev8OqzlOAPljR9j-details-user-provided">' + node.click + '</div>';
                 }
                 ui.elements.detailsBody.innerHTML = htmlText;
               }
@@ -3156,7 +3156,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
 
               // 1) Remove existing elements
               ui.composites.graph.removeEdges();
-              svg.select("#i8EK4UFXUqNxcNnZd-arrow-marker").remove();
+              svg.select("#imev8OqzlOAPljR9j-arrow-marker").remove();
               // 2) Create new elements
               // - Paths
               state.currentGraphParts.edgePaths = edgeGroups.append("path")
@@ -3170,7 +3170,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                 const arrowSizeDouble = arrowSize * 2.0,
                   arrowSizeHalf = arrowSize / 2.0;
                 const marker = svg.append("marker")
-                  .attr("id", "i8EK4UFXUqNxcNnZd-arrow-marker")
+                  .attr("id", "imev8OqzlOAPljR9j-arrow-marker")
                   .attr("markerUnits", "userSpaceOnUse")
                   .attr("viewBox", "0 0 " + arrowSizeDouble + " " + arrowSizeDouble)
                   .attr("refX", 0)
@@ -3183,7 +3183,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
                     .attr("d", "M 0 0 L " + arrowSizeDouble + " " + arrowSizeHalf + " L 0 " + arrowSize + " z")
                     .attr("fill", state.shownData.general.arrow_color)
                 state.currentGraphParts.edgePaths
-                  .attr("marker-end", "url(#i8EK4UFXUqNxcNnZd-arrow-marker)");
+                  .attr("marker-end", "url(#imev8OqzlOAPljR9j-arrow-marker)");
               }
               // - Edge hover behavior
               if(state.parsedData.general.contains_edge_hover){
@@ -3217,7 +3217,7 @@ function(t){"use strict";function n(t,n){return null==t||null==n?NaN:t<n?-1:t>n?
               function edgeClicked(event, edge){
                 let htmlText = "<div>Edge: " + String(edge.id) + "</div>";
                 if(typeof(edge.click) !== "undefined" && edge.click !== ""){
-                  htmlText += '<div id="i8EK4UFXUqNxcNnZd-details-user-provided">' + edge.click + '</div>';
+                  htmlText += '<div id="imev8OqzlOAPljR9j-details-user-provided">' + edge.click + '</div>';
                 }
                 ui.elements.detailsBody.innerHTML = htmlText;
               }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Gene Normalizer |version|
      :alt: citation
      :target: https://zenodo.org/badge/latestdoi/309797998
 
-The Gene Normalizer provides tools for resolving ambiguous human gene references to consistently-structured, normalized terms. For gene concepts extracted from `NCBI Gene <https://www.ncbi.nlm.nih.gov/gene/>`_, `Ensembl <https://useast.ensembl.org/index.html>`_, and `HGNC <https://www.genenames.org/>`_, it designates a `CURIE <https://en.wikipedia.org/wiki/CURIE>`_, and provides additional metadata like current and previously-used symbols, aliases, database cross-references and associations, and coordinates.
+The Gene Normalizer provides tools for resolving ambiguous human gene references to consistently-structured, normalized terms. For gene concepts extracted from `NCBI Gene <https://www.ncbi.nlm.nih.gov/gene/>`_, `Ensembl <https://useast.ensembl.org/index.html>`_, and `HGNC <https://www.genenames.org/>`_, it designates a `CURIE <https://en.wikipedia.org/wiki/CURIE>`_, and provides additional metadata like current and previously-used symbols, aliases, database cross-references, and coordinates.
 
 A `public REST instance of the service <https://normalize.cancervariants.org/gene>`_ is available for programmatic queries:
 

--- a/docs/source/managing_data/index.rst
+++ b/docs/source/managing_data/index.rst
@@ -1,11 +1,10 @@
 Managing data
 =============
 
-The current iteration of the Gene Normalizer stores millions of symbols, names, cross-references, and other associations. This section describes how to load and refresh data, and details usage of specific backend storage implementations.
+The current iteration of the Gene Normalizer stores millions of symbols, names, cross-references, and other information. This section describes how to load and refresh data, and details usage of specific backend storage implementations.
 
 .. toctree::
 
     Loading and updating data<loading_and_updating_data>
     DynamoDB storage backend<dynamodb>
     PostgreSQL storage backend<postgresql>
-

--- a/docs/source/normalizing_data/sources.rst
+++ b/docs/source/normalizing_data/sources.rst
@@ -33,9 +33,7 @@ HGNC
      "previous_symbols": [],
      "xrefs": [
        "ensembl:ENSG00000157764",
-       "ncbigene:673"
-     ],
-     "associated_with": [
+       "ncbigene:673",
        "uniprot:P15056",
        "pubmed:2284096",
        "omim:164757",
@@ -99,7 +97,6 @@ Ensembl
      "xrefs": [
        "hgnc:1097"
      ],
-     "associated_with": [],
      "gene_type": "protein_coding",
      "match_type": 100
    }
@@ -143,9 +140,7 @@ The `NCBI Gene Database <https://www.ncbi.nlm.nih.gov/gene/>`_ is a service prov
       "previous_symbols": [],
       "xrefs": [
         "ensembl:ENSG00000157764",
-        "hgnc:1097"
-      ],
-      "associated_with": [
+        "hgnc:1097",
         "omim:164757"
       ],
       "gene_type": "protein-coding",

--- a/src/gene/database/dynamodb.py
+++ b/src/gene/database/dynamodb.py
@@ -434,8 +434,7 @@ class DynamoDbDatabase(AbstractDatabase):
 
         :param str term: referent term
         :param str concept_id: concept ID to refer to
-        :param str ref_type: one of {'alias', 'label', 'xref',
-            'associated_with'}
+        :param str ref_type: one of {'alias', 'label', 'xref'}
         :param src_name: name of source for record
         """
         label_and_type = f"{term.lower()}##{ref_type}"

--- a/src/gene/database/postgresql/add_fkeys.sql
+++ b/src/gene/database/postgresql/add_fkeys.sql
@@ -1,7 +1,5 @@
 ALTER TABLE gene_aliases ADD CONSTRAINT gene_aliases_concept_id_fkey
     FOREIGN KEY (concept_id) REFERENCES gene_concepts (concept_id);
-ALTER TABLE gene_associations ADD CONSTRAINT gene_associations_concept_id_fkey
-    FOREIGN KEY (concept_id) REFERENCES gene_concepts (concept_id);
 ALTER TABLE gene_previous_symbols
     ADD CONSTRAINT gene_previous_symbols_concept_id_fkey
     FOREIGN KEY (concept_id) REFERENCES gene_concepts (concept_id);

--- a/src/gene/database/postgresql/add_indexes.sql
+++ b/src/gene/database/postgresql/add_indexes.sql
@@ -7,7 +7,5 @@ CREATE INDEX idx_gps_symbol_low
     ON gene_previous_symbols (lower(prev_symbol));
 CREATE INDEX idx_ga_alias_low ON gene_aliases (lower(alias));
 CREATE INDEX idx_gx_xref_low ON gene_xrefs (lower(xref));
-CREATE INDEX idx_g_as_association_low
-    ON gene_associations (lower(associated_with));
 CREATE INDEX idx_rlv_concept_id_low
     ON record_lookup_view (lower(concept_id));

--- a/src/gene/database/postgresql/create_record_lookup_view.sql
+++ b/src/gene/database/postgresql/create_record_lookup_view.sql
@@ -7,7 +7,6 @@ SELECT gc.concept_id,
        gc.locations,
        gc.gene_type,
        ga.aliases,
-       gas.associated_with,
        gps.previous_symbols,
        gs.symbol,
        gx.xrefs,
@@ -20,11 +19,6 @@ FULL JOIN (
     FROM gene_aliases ga_1
     GROUP BY ga_1.concept_id
 ) ga ON gc.concept_id::text = ga.concept_id::text
-FULL JOIN (
-    SELECT gas_1.concept_id, array_agg(gas_1.associated_with) AS associated_with
-    FROM gene_associations gas_1
-    GROUP BY gas_1.concept_id
-) gas ON gc.concept_id::text = gas.concept_id::text
 FULL JOIN (
     SELECT gps_1.concept_id, array_agg(gps_1.prev_symbol) AS previous_symbols
     FROM gene_previous_symbols gps_1

--- a/src/gene/database/postgresql/create_tables.sql
+++ b/src/gene/database/postgresql/create_tables.sql
@@ -26,7 +26,6 @@ CREATE TABLE gene_merged (
     hgnc_locus_type TEXT [],
     ncbi_gene_type TEXT [],
     aliases TEXT [],
-    associated_with TEXT [],
     xrefs TEXT []
 );
 CREATE TABLE gene_concepts (
@@ -59,9 +58,4 @@ CREATE TABLE gene_xrefs (
     id SERIAL PRIMARY KEY,
     xref TEXT NOT NULL,
     concept_id VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)
-);
-CREATE TABLE gene_associations (
-    id SERIAL PRIMARY KEY,
-    associated_with TEXT NOT NULL,
-    concept_ID VARCHAR(127) NOT NULL REFERENCES gene_concepts (concept_id)
 );

--- a/src/gene/database/postgresql/delete_normalized_concepts.sql
+++ b/src/gene/database/postgresql/delete_normalized_concepts.sql
@@ -19,7 +19,6 @@ CREATE TABLE gene_merged (
     hgnc_locus_type TEXT [],
     ncbi_gene_type TEXT [],
     aliases TEXT [],
-    associated_with TEXT [],
     xrefs TEXT []
 );
 ALTER TABLE gene_concepts ADD CONSTRAINT gene_concepts_merge_ref_fkey

--- a/src/gene/database/postgresql/drop_fkeys.sql
+++ b/src/gene/database/postgresql/drop_fkeys.sql
@@ -1,5 +1,4 @@
 ALTER TABLE gene_aliases DROP CONSTRAINT gene_aliases_concept_id_fkey;
-ALTER TABLE gene_associations DROP CONSTRAINT gene_associations_concept_id_fkey;
 ALTER TABLE gene_previous_symbols
     DROP CONSTRAINT gene_previous_symbols_concept_id_fkey;
 ALTER TABLE gene_symbols DROP CONSTRAINT gene_symbols_concept_id_fkey;

--- a/src/gene/database/postgresql/drop_indexes.sql
+++ b/src/gene/database/postgresql/drop_indexes.sql
@@ -4,5 +4,4 @@ DROP INDEX IF EXISTS idx_gs_symbol_low;
 DROP INDEX IF EXISTS idx_gps_symbol_low;
 DROP INDEX IF EXISTS idx_gx_xref_low;
 DROP INDEX IF EXISTS idx_ga_alias_low;
-DROP INDEX IF EXISTS idx_g_as_association_low;
 DROP INDEX IF EXISTS idx_rlv_concept_id_low;

--- a/src/gene/etl/merge.py
+++ b/src/gene/etl/merge.py
@@ -158,12 +158,16 @@ class Merge:
             "ensembl_biotype": set(),
             "strand": set(),
         }
-        if len(records) > 1:
-            merged_attrs["xrefs"] = list({r["concept_id"] for r in records[1:]})
 
         # merge from constituent records
         set_fields = ["aliases", "previous_symbols", "strand"]
-        scalar_fields = ["symbol", "symbol_status", "label", "location_annotations"]
+        scalar_fields = [
+            "symbol",
+            "symbol_status",
+            "label",
+            "location_annotations",
+            "xrefs",
+        ]
         for record in records:
             for field in set_fields:
                 merged_attrs[field] |= set(record.get(field, set()))

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -375,9 +375,8 @@ class QueryHandler:
         )
 
         # mappings
-        source_ids = record.get("xrefs", []) + record.get("associated_with", [])
         mappings = []
-        for source_id in source_ids:
+        for source_id in record.get("xrefs", []):
             system, code = source_id.split(":")
             mappings.append(
                 core_models.Mapping(

--- a/src/gene/schemas.py
+++ b/src/gene/schemas.py
@@ -58,7 +58,6 @@ class MatchType(IntEnum):
     PREV_SYMBOL = 80
     ALIAS = 60
     XREF = 60
-    ASSOCIATED_WITH = 60
     FUZZY_MATCH = 20
     NO_MATCH = 0
 
@@ -102,7 +101,6 @@ class BaseGene(BaseModel):
     aliases: List[StrictStr] = []
     previous_symbols: List[StrictStr] = []
     xrefs: List[CURIE] = []
-    associated_with: List[CURIE] = []
     gene_type: Optional[StrictStr] = None
 
 
@@ -242,7 +240,6 @@ class RefType(str, Enum):
     PREVIOUS_SYMBOLS = "prev_symbol"
     ALIASES = "alias"
     XREFS = "xref"
-    ASSOCIATED_WITH = "associated_with"
 
 
 # collective name to singular name, e.g. {"previous_symbols": "prev_symbol"}
@@ -561,8 +558,9 @@ class UnmergedNormalizationService(BaseNormalizationService):
                                 ],
                                 "aliases": ["3.1.1.7"],
                                 "previous_symbols": ["YT"],
-                                "xrefs": ["ncbigene:43", "ensembl:ENSG00000087085"],
-                                "associated_with": [
+                                "xrefs": [
+                                    "ncbigene:43",
+                                    "ensembl:ENSG00000087085",
                                     "ucsc:uc003uxi.4",
                                     "vega:OTTHUMG00000157033",
                                     "merops:S09.979",
@@ -671,8 +669,6 @@ class UnmergedNormalizationService(BaseNormalizationService):
                                 "xrefs": [
                                     "hgnc:108",
                                     "ensembl:ENSG00000087085",
-                                ],
-                                "associated_with": [
                                     "omim:100740",
                                 ],
                                 "gene_type": "protein-coding",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def _compare_records(normalized_gene, test_gene, match_type):
     assert set(normalized_gene.xrefs) == set(test_gene.xrefs)
     assert normalized_gene.symbol_status == test_gene.symbol_status
     assert set(normalized_gene.previous_symbols) == set(test_gene.previous_symbols)
-    assert set(normalized_gene.associated_with) == set(test_gene.associated_with)
     assert normalized_gene.symbol == test_gene.symbol
     assert len(normalized_gene.locations) == len(test_gene.locations)
     for loc in normalized_gene.locations:

--- a/tests/unit/test_database_and_etl.py
+++ b/tests/unit/test_database_and_etl.py
@@ -76,7 +76,6 @@ def test_tables_created(db_fixture):
     existing_tables = db_fixture.db.list_tables()
     if db_fixture.db_name == "PostgresDatabase":
         assert set(existing_tables) == {
-            "gene_associations",
             "gene_symbols",
             "gene_previous_symbols",
             "gene_aliases",
@@ -149,11 +148,6 @@ def test_item_type(db_fixture):
     item = db_fixture.db.genes.query(KeyConditionExpression=filter_exp)["Items"][0]
     assert "item_type" in item
     assert item["item_type"] == "alias"
-
-    filter_exp = Key("label_and_type").eq("omim:606689##associated_with")
-    item = db_fixture.db.genes.query(KeyConditionExpression=filter_exp)["Items"][0]
-    assert "item_type" in item
-    assert item["item_type"] == "associated_with"
 
     filter_exp = Key("label_and_type").eq("ensembl:ensg00000268895##xref")
     item = db_fixture.db.genes.query(KeyConditionExpression=filter_exp)["Items"][0]

--- a/tests/unit/test_ensembl_source.py
+++ b/tests/unit/test_ensembl_source.py
@@ -47,7 +47,6 @@ def ddx11l1():
             }
         ],
         "strand": "+",
-        "associated_with": [],
         "gene_type": "transcribed_unprocessed_pseudogene",
     }
     return Gene(**params)
@@ -79,7 +78,6 @@ def tp53():
             }
         ],
         "strand": "-",
-        "associated_with": [],
         "gene_type": "protein_coding",
     }
     return Gene(**params)
@@ -111,7 +109,6 @@ def ATP6AP1_DT():  # noqa: N802
             }
         ],
         "strand": "-",
-        "associated_with": [],
         "gene_type": "lncRNA",
     }
     return Gene(**params)
@@ -127,7 +124,6 @@ def hsa_mir_1253():
         "label": "hsa-mir-1253",
         "previous_symbols": [],
         "aliases": [],
-        "xrefs": [],
         "symbol_status": None,
         "location_annotations": [],
         "locations": [
@@ -143,7 +139,7 @@ def hsa_mir_1253():
             }
         ],
         "strand": "+",
-        "associated_with": ["mirbase:MI0006387"],
+        "xrefs": ["mirbase:MI0006387"],
         "gene_type": "lncRNA",
     }
     return Gene(**params)
@@ -175,7 +171,6 @@ def spry3():
             }
         ],
         "strand": "+",
-        "associated_with": [],
         "gene_type": "protein_coding",
     }
     return Gene(**params)
@@ -254,9 +249,9 @@ def test_hsa_mir_1253(check_resp_single_record, ensembl, hsa_mir_1253):
     resp = ensembl.search("hsa-mir-1253")
     check_resp_single_record(resp, hsa_mir_1253, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = ensembl.search("mirbase:MI0006387")
-    check_resp_single_record(resp, hsa_mir_1253, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, hsa_mir_1253, MatchType.XREF)
 
 
 def test_spry3(check_resp_single_record, ensembl, spry3):

--- a/tests/unit/test_hgnc_source.py
+++ b/tests/unit/test_hgnc_source.py
@@ -49,7 +49,9 @@ def a1bg_as1():
         "previous_symbols": ["NCRNA00181", "A1BGAS", "A1BG-AS"],
         "aliases": ["FLJ23569"],
         "symbol_status": "approved",
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000268895",
+            "ncbigene:503538",
             "vega:OTTHUMG00000183508",
             "ucsc:uc002qse.3",
             "refseq:NR_015380",
@@ -57,7 +59,6 @@ def a1bg_as1():
             "refseq:NR_015380",
             "ena.embl:BC040926",
         ],
-        "xrefs": ["ensembl:ENSG00000268895", "ncbigene:503538"],
         "gene_type": "RNA, long non-coding",
     }
     return Gene(**params)
@@ -86,7 +87,7 @@ def tp53():
         "previous_symbols": [],
         "aliases": ["p53", "LFS1"],
         "symbol_status": "approved",
-        "associated_with": [
+        "xrefs": [
             "vega:OTTHUMG00000162125",
             "refseq:NM_000546",
             "cosmic:TP53",
@@ -110,8 +111,9 @@ def tp53():
             "pubmed:6396087",
             "pubmed:3456488",
             "pubmed:2047879",
+            "ensembl:ENSG00000141510",
+            "ncbigene:7157",
         ],
-        "xrefs": ["ensembl:ENSG00000141510", "ncbigene:7157"],
         "gene_type": "gene with protein product",
     }
     return Gene(**params)
@@ -140,8 +142,9 @@ def a3galt2():
         "previous_symbols": ["A3GALT2P"],
         "aliases": ["IGBS3S", "IGB3S"],
         "symbol_status": "approved",
-        "xrefs": ["ensembl:ENSG00000184389", "ncbigene:127550"],
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000184389",
+            "ncbigene:127550",
             "vega:OTTHUMG00000004125",
             "vega:OTTHUMG00000004125",
             "ucsc:uc031plq.1",
@@ -180,8 +183,9 @@ def wdhd1():
         "previous_symbols": [],
         "aliases": ["AND-1", "CTF4", "CHTF4"],
         "symbol_status": "approved",
-        "xrefs": ["ensembl:ENSG00000198554", "ncbigene:11169"],
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000198554",
+            "ncbigene:11169",
             "vega:OTTHUMG00000140304",
             "refseq:NM_007086",
             "omim:608126",
@@ -212,8 +216,12 @@ def g6pr():
         "previous_symbols": [],
         "aliases": ["GSD1aSP"],
         "symbol_status": "approved",
-        "xrefs": ["ncbigene:2541"],
-        "associated_with": ["pubmed:2172641", "pubmed:7814621", "pubmed:2996501"],
+        "xrefs": [
+            "ncbigene:2541",
+            "pubmed:2172641",
+            "pubmed:7814621",
+            "pubmed:2996501",
+        ],
         "gene_type": "unknown",
     }
     return Gene(**params)
@@ -233,8 +241,7 @@ def pirc24():
         "previous_symbols": [],
         "aliases": [],
         "symbol_status": "approved",
-        "xrefs": ["ncbigene:100313810"],
-        "associated_with": ["pubmed:17881367"],
+        "xrefs": ["ncbigene:100313810", "pubmed:17881367"],
         "gene_type": "RNA, cluster",
     }
     return Gene(**params)
@@ -263,8 +270,8 @@ def gage4():
         "previous_symbols": [],
         "aliases": ["CT4.4"],
         "symbol_status": "approved",
-        "xrefs": ["ncbigene:2576"],
-        "associated_with": [
+        "xrefs": [
+            "ncbigene:2576",
             "refseq:NM_001474",
             "omim:300597",
             "uniprot:P0DSO3",
@@ -290,8 +297,9 @@ def mafip():
         "previous_symbols": [],
         "aliases": ["FLJ35473", "FLJ00219", "FLJ39633", "MIP", "pp5644", "TEKT4P4"],
         "symbol_status": "approved",
-        "xrefs": ["ensembl:ENSG00000274847", "ncbigene:727764"],
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000274847",
+            "ncbigene:727764",
             "vega:OTTHUMG00000188065",
             "refseq:NR_046439",
             "uniprot:Q8WZ33",
@@ -319,8 +327,7 @@ def mt_7sdna():
         "previous_symbols": ["MT7SDNA"],
         "aliases": [],
         "symbol_status": "approved",
-        "xrefs": [],
-        "associated_with": ["pubmed:24709344", "pubmed:273237"],
+        "xrefs": ["pubmed:24709344", "pubmed:273237"],
         "gene_type": "region",
     }
     return Gene(**params)
@@ -350,7 +357,6 @@ def cecr():
         "aliases": [],
         "symbol_status": "approved",
         "xrefs": ["ncbigene:1055"],
-        "associated_with": [],
         "gene_type": "region",
     }
     return Gene(**params)
@@ -387,8 +393,9 @@ def csf2ra():
         "previous_symbols": ["CSF2R"],
         "aliases": ["CD116", "alphaGMR"],
         "symbol_status": "approved",
-        "xrefs": ["ensembl:ENSG00000198223", "ncbigene:1438"],
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000198223",
+            "ncbigene:1438",
             "vega:OTTHUMG00000012533",
             "refseq:NM_001161529",
             "orphanet:209477",
@@ -435,8 +442,7 @@ def rps24p5():
         "previous_symbols": [],
         "aliases": [],
         "symbol_status": "approved",
-        "xrefs": ["ncbigene:100271094"],
-        "associated_with": ["refseq:NG_011274", "pubmed:19123937"],
+        "xrefs": ["ncbigene:100271094", "refseq:NG_011274", "pubmed:19123937"],
         "gene_type": "pseudogene",
     }
     return Gene(**params)
@@ -465,8 +471,7 @@ def trl_cag2_1():
         "previous_symbols": ["TRNAL13"],
         "aliases": ["tRNA-Leu-CAG-2-1"],
         "symbol_status": "approved",
-        "xrefs": ["ncbigene:100189130"],
-        "associated_with": ["ena.embl:HG983896"],
+        "xrefs": ["ncbigene:100189130", "ena.embl:HG983896"],
         "gene_type": "RNA, transfer",
     }
     return Gene(**params)
@@ -495,8 +500,9 @@ def myo5b():
         "previous_symbols": [],
         "aliases": ["KIAA1119"],
         "symbol_status": "approved",
-        "xrefs": ["ensembl:ENSG00000167306", "ncbigene:4645"],
-        "associated_with": [
+        "xrefs": [
+            "ensembl:ENSG00000167306",
+            "ncbigene:4645",
             "vega:OTTHUMG00000179843",
             "refseq:NM_001080467",
             "omim:606540",
@@ -539,7 +545,7 @@ def gstt1():
         "previous_symbols": [],
         "aliases": ["2.5.1.18"],
         "symbol_status": "approved",
-        "associated_with": [
+        "xrefs": [
             "refseq:NM_000853",
             "omim:600436",
             "ucsc:uc002zze.4",
@@ -547,8 +553,9 @@ def gstt1():
             "orphanet:470418",
             "ena.embl:KI270879",
             "pubmed:8617495",
+            "ensembl:ENSG00000277656",
+            "ncbigene:2952",
         ],
-        "xrefs": ["ensembl:ENSG00000277656", "ncbigene:2952"],
         "gene_type": "gene with protein product",
     }
     return Gene(**params)
@@ -772,9 +779,9 @@ def test_myo5b(check_resp_single_record, myo5b, hgnc):
     resp = hgnc.search("MYO5B")
     check_resp_single_record(resp, myo5b, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = hgnc.search("refseq:NM_001080467")
-    check_resp_single_record(resp, myo5b, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, myo5b, MatchType.XREF)
 
 
 def test_gstt1(check_resp_single_record, gstt1, hgnc):
@@ -787,9 +794,9 @@ def test_gstt1(check_resp_single_record, gstt1, hgnc):
     resp = hgnc.search("GSTT1")
     check_resp_single_record(resp, gstt1, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = hgnc.search("omim:600436")
-    check_resp_single_record(resp, gstt1, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, gstt1, MatchType.XREF)
 
 
 def test_no_match(hgnc):

--- a/tests/unit/test_ncbi_source.py
+++ b/tests/unit/test_ncbi_source.py
@@ -22,7 +22,6 @@ def check_ncbi_discontinued_gene(normalizer_response, concept_id, symbol, match_
     assert resp.aliases == []
     assert resp.previous_symbols == []
     assert resp.xrefs == []
-    assert resp.associated_with == []
 
 
 @pytest.fixture(scope="module")
@@ -50,9 +49,8 @@ def dpf1():
         "concept_id": "ncbigene:8193",
         "symbol": "DPF1",
         "aliases": ["BAF45b", "NEUD4", "neuro-d4", "SMARCG1"],
-        "xrefs": ["hgnc:20225", "ensembl:ENSG00000011332"],
         "previous_symbols": [],
-        "associated_with": ["omim:601670"],
+        "xrefs": ["hgnc:20225", "ensembl:ENSG00000011332", "omim:601670"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": "-",
@@ -90,9 +88,8 @@ def pdp1_symbol():
         "concept_id": "ncbigene:54704",
         "symbol": "PDP1",
         "aliases": ["PDH", "PDP", "PDPC", "PPM2A", "PPM2C"],
-        "xrefs": ["hgnc:9279", "ensembl:ENSG00000164951"],
+        "xrefs": ["hgnc:9279", "ensembl:ENSG00000164951", "omim:605993"],
         "previous_symbols": ["LOC157663", "PPM2C"],
-        "associated_with": ["omim:605993"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": "+",
@@ -130,9 +127,8 @@ def pdp1_alias():
         "concept_id": "ncbigene:403313",
         "symbol": "PLPP6",
         "aliases": ["PDP1", "PSDP", "PPAPDC2", "bA6J24.6", "LPRP-B", "PA-PSP"],
-        "xrefs": ["hgnc:23682", "ensembl:ENSG00000205808"],
+        "xrefs": ["hgnc:23682", "ensembl:ENSG00000205808", "omim:611666"],
         "previous_symbols": [],
-        "associated_with": ["omim:611666"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": "+",
@@ -171,9 +167,8 @@ def spry3():
         "concept_id": "ncbigene:10251",
         "symbol": "SPRY3",
         "aliases": ["spry-3"],
-        "xrefs": ["hgnc:11271", "ensembl:ENSG00000168939"],
+        "xrefs": ["hgnc:11271", "ensembl:ENSG00000168939", "omim:300531"],
         "previous_symbols": ["LOC170187", "LOC253479"],
-        "associated_with": ["omim:300531"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": "+",
@@ -232,7 +227,6 @@ def adcp1():
         "aliases": [],
         "xrefs": ["hgnc:229"],
         "previous_symbols": [],
-        "associated_with": [],
         "symbol_status": None,
         "strand": None,
         "location_annotations": ["6"],
@@ -252,9 +246,8 @@ def afa():
         "concept_id": "ncbigene:170",
         "symbol": "AFA",
         "aliases": [],
-        "xrefs": [],
         "previous_symbols": [],
-        "associated_with": ["omim:106250"],
+        "xrefs": ["omim:106250"],
         "symbol_status": None,
         "strand": None,
         "location_annotations": [],
@@ -274,9 +267,8 @@ def znf84():
         "concept_id": "ncbigene:7637",
         "symbol": "ZNF84",
         "aliases": ["HPF2"],
-        "xrefs": ["hgnc:13159", "ensembl:ENSG00000198040"],
+        "xrefs": ["hgnc:13159", "ensembl:ENSG00000198040", "omim:618554"],
         "previous_symbols": ["LOC100287429"],
-        "associated_with": ["omim:618554"],
         "symbol_status": None,
         "location_annotations": ["map from Rosati ref via FISH [AFS]"],
         "strand": "+",
@@ -315,9 +307,14 @@ def slc25a6():
         "concept_id": "ncbigene:293",
         "symbol": "SLC25A6",
         "aliases": ["AAC3", "ANT", "ANT 2", "ANT 3", "ANT3", "ANT3Y"],
-        "xrefs": ["hgnc:10992", "ensembl:ENSG00000169100", "ensembl:ENSG00000292334"],
+        "xrefs": [
+            "hgnc:10992",
+            "ensembl:ENSG00000169100",
+            "ensembl:ENSG00000292334",
+            "omim:300151",
+            "omim:403000",
+        ],
         "previous_symbols": ["ANT3Y"],
-        "associated_with": ["omim:300151", "omim:403000"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": "-",
@@ -376,7 +373,6 @@ def loc106783576():
         "aliases": [],
         "xrefs": [],
         "previous_symbols": [],
-        "associated_with": [],
         "symbol_status": None,
         "location_annotations": [],
         "strand": None,
@@ -405,9 +401,8 @@ def glc1b():
         "concept_id": "ncbigene:2722",
         "symbol": "GLC1B",
         "aliases": [],
-        "xrefs": [],
         "previous_symbols": [],
-        "associated_with": ["omim:606689"],
+        "xrefs": ["omim:606689"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": None,
@@ -436,9 +431,8 @@ def hdpa():
         "concept_id": "ncbigene:50829",
         "symbol": "HDPA",
         "aliases": [],
-        "xrefs": [],
         "previous_symbols": [],
-        "associated_with": ["omim:300221"],
+        "xrefs": ["omim:300221"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": None,
@@ -470,7 +464,6 @@ def prkrap1():
         "aliases": [],
         "xrefs": ["hgnc:33447"],
         "previous_symbols": ["LOC100289695"],
-        "associated_with": [],
         "symbol_status": None,
         "location_annotations": ["alternate reference locus"],
         "strand": "+",
@@ -519,9 +512,8 @@ def mhb():
         "concept_id": "ncbigene:619511",
         "symbol": "MHB",
         "aliases": [],
-        "xrefs": [],
         "previous_symbols": [],
-        "associated_with": ["omim:255160"],
+        "xrefs": ["omim:255160"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": None,
@@ -550,9 +542,8 @@ def spg37():
         "concept_id": "ncbigene:100049159",
         "symbol": "SPG37",
         "aliases": [],
-        "xrefs": [],
         "previous_symbols": [],
-        "associated_with": ["omim:611945"],
+        "xrefs": ["omim:611945"],
         "symbol_status": None,
         "location_annotations": [],
         "strand": None,
@@ -607,9 +598,9 @@ def test_dpf1(check_resp_single_record, ncbi, dpf1):
     resp = ncbi.search("neuro-d4")
     check_resp_single_record(resp, dpf1, MatchType.ALIAS)
 
-    # associated_with
+    # xref
     resp = ncbi.search("omim:601670")
-    check_resp_single_record(resp, dpf1, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, dpf1, MatchType.XREF)
 
     # No Match
     resp = ncbi.search("DPF 1")
@@ -751,9 +742,9 @@ def test_glc1b(check_resp_single_record, ncbi, glc1b):
     resp = ncbi.search("GLC1B")
     check_resp_single_record(resp, glc1b, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = ncbi.search("omim:606689")
-    check_resp_single_record(resp, glc1b, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, glc1b, MatchType.XREF)
 
 
 def test_hdpa(check_resp_single_record, ncbi, hdpa):
@@ -792,9 +783,9 @@ def test_mhb(check_resp_single_record, ncbi, mhb):
     resp = ncbi.search("MHB")
     check_resp_single_record(resp, mhb, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = ncbi.search("OMIM:255160")
-    check_resp_single_record(resp, mhb, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, mhb, MatchType.XREF)
 
 
 def test_spg37(check_resp_single_record, ncbi, spg37):
@@ -807,9 +798,9 @@ def test_spg37(check_resp_single_record, ncbi, spg37):
     resp = ncbi.search("SPG37")
     check_resp_single_record(resp, spg37, MatchType.SYMBOL)
 
-    # associated_with
+    # xref
     resp = ncbi.search("omim:611945")
-    check_resp_single_record(resp, spg37, MatchType.ASSOCIATED_WITH)
+    check_resp_single_record(resp, spg37, MatchType.XREF)
 
 
 def test_discontinued_genes(ncbi):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -702,7 +702,6 @@ def normalize_unmerged_loc_653303():
                         "aliases": [],
                         "previous_symbols": ["LOC196266", "LOC731196", "LOC654080"],
                         "xrefs": [],
-                        "associated_with": [],
                         "gene_type": "pseudo",
                     }
                 ]
@@ -745,8 +744,9 @@ def normalize_unmerged_chaf1a():
                             "CAF-1",
                         ],
                         "previous_symbols": [],
-                        "xrefs": ["ensembl:ENSG00000167670", "ncbigene:10036"],
-                        "associated_with": [
+                        "xrefs": [
+                            "ensembl:ENSG00000167670",
+                            "ncbigene:10036",
                             "vega:OTTHUMG00000181922",
                             "ccds:CCDS32875",
                             "ucsc:uc002mal.4",
@@ -784,7 +784,6 @@ def normalize_unmerged_chaf1a():
                         "aliases": [],
                         "previous_symbols": [],
                         "xrefs": ["hgnc:1910"],
-                        "associated_with": [],
                         "gene_type": "protein_coding",
                     }
                 ],
@@ -820,8 +819,11 @@ def normalize_unmerged_chaf1a():
                         ],
                         "aliases": ["CAF1P150", "P150", "CAF1", "CAF1B", "CAF-1"],
                         "previous_symbols": ["LOC107985297"],
-                        "xrefs": ["ensembl:ENSG00000167670", "hgnc:1910"],
-                        "associated_with": ["omim:601246"],
+                        "xrefs": [
+                            "ensembl:ENSG00000167670",
+                            "hgnc:1910",
+                            "omim:601246",
+                        ],
                         "gene_type": "protein-coding",
                     }
                 ]
@@ -867,8 +869,7 @@ def normalize_unmerged_ache():
                         ],
                         "aliases": ["YT", "ARACHE", "ACEE", "N-ACHE"],
                         "previous_symbols": ["ACEE"],
-                        "xrefs": ["hgnc:108", "ensembl:ENSG00000087085"],
-                        "associated_with": ["omim:100740"],
+                        "xrefs": ["hgnc:108", "ensembl:ENSG00000087085", "omim:100740"],
                         "gene_type": "protein-coding",
                     }
                 ],
@@ -897,7 +898,6 @@ def normalize_unmerged_ache():
                         "aliases": [],
                         "previous_symbols": [],
                         "xrefs": ["hgnc:108"],
-                        "associated_with": [],
                         "gene_type": "protein_coding",
                     }
                 ]
@@ -923,8 +923,9 @@ def normalize_unmerged_ache():
                         ],
                         "aliases": ["3.1.1.7"],
                         "previous_symbols": ["YT"],
-                        "xrefs": ["ncbigene:43", "ensembl:ENSG00000087085"],
-                        "associated_with": [
+                        "xrefs": [
+                            "ncbigene:43",
+                            "ensembl:ENSG00000087085",
                             "ucsc:uc003uxi.4",
                             "vega:OTTHUMG00000157033",
                             "merops:S09.979",
@@ -1050,7 +1051,6 @@ def compare_unmerged_record(gene, test_gene):
     assert set(gene.xrefs) == set(test_gene.xrefs)
     assert gene.symbol_status == test_gene.symbol_status
     assert set(gene.previous_symbols) == set(test_gene.previous_symbols)
-    assert set(gene.associated_with) == set(test_gene.associated_with)
     assert gene.symbol == test_gene.symbol
     assert len(gene.locations) == len(test_gene.locations)
     for loc in gene.locations:
@@ -1259,7 +1259,7 @@ def test_ache_query(query_handler, num_sources, normalized_ache, source_meta):
     compare_normalize_resp(
         resp,
         q,
-        MatchType.ASSOCIATED_WITH,
+        MatchType.XREF,
         normalized_ache,
         expected_source_meta=source_meta,
     )
@@ -1337,7 +1337,7 @@ def test_braf_query(query_handler, num_sources, normalized_braf, source_meta):
     compare_normalize_resp(
         resp,
         q,
-        MatchType.ASSOCIATED_WITH,
+        MatchType.XREF,
         normalized_braf,
         expected_source_meta=source_meta,
     )
@@ -1439,7 +1439,7 @@ def test_abl1_query(query_handler, num_sources, normalized_abl1, source_meta):
     compare_normalize_resp(
         resp,
         q,
-        MatchType.ASSOCIATED_WITH,
+        MatchType.XREF,
         normalized_abl1,
         expected_source_meta=source_meta,
     )
@@ -1572,18 +1572,14 @@ def test_normalize_unmerged(
     resp = query_handler.normalize_unmerged(q)
     compare_unmerged_response(resp, q, [], MatchType.ALIAS, normalize_unmerged_chaf1a)
 
-    # assoc with
+    # xref
     q = "omim:100740"
     resp = query_handler.normalize_unmerged(q)
-    compare_unmerged_response(
-        resp, q, [], MatchType.ASSOCIATED_WITH, normalize_unmerged_ache
-    )
+    compare_unmerged_response(resp, q, [], MatchType.XREF, normalize_unmerged_ache)
 
     q = "uniprot:Q13111"
     resp = query_handler.normalize_unmerged(q)
-    compare_unmerged_response(
-        resp, q, [], MatchType.ASSOCIATED_WITH, normalize_unmerged_chaf1a
-    )
+    compare_unmerged_response(resp, q, [], MatchType.XREF, normalize_unmerged_chaf1a)
 
 
 def test_invalid_queries(query_handler):

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -78,15 +78,6 @@ def test_gene(gene, sequence_location):
             xrefs=["hgnc", "hgnc:1"],
         )
 
-    # associated_with not a valid curie
-    with pytest.raises(pydantic.ValidationError):
-        Gene(
-            match_type=100,
-            concept_id="hgnc:1096",
-            symbol="BRAF",
-            associated_with=["hgnc", "hgnc:1"],
-        )
-
     # symbol status invalid
     with pytest.raises(pydantic.ValidationError):
         Gene(


### PR DESCRIPTION
The original source Gene object structure was sort of just something we (Alex) came up with back in the day. Now we have a GKS object that doesn't distinguish between `xrefs` and `associated_with` (this was always kind of a funny distinction anyway). This PR builds toward usage of the GKS Gene object across all response types by merging `associated_with` into `xrefs`.

Most of this PR is just ctrl+f find/replace, but there is some small refactoring of the ETL methods since this change enables some simplification.