### PR TITLE
fix: handle password param in postgres connection

### DIFF
--- a/src/gene/database/postgresql.py
+++ b/src/gene/database/postgresql.py
@@ -803,7 +803,7 @@ class PostgresDatabase(AbstractDatabase):
             dump_file = tempdir_path / tar_dump_file.name
 
             self.drop_db()
-            system_call = f"psql {self.conninfo} -f {dump_file.absolute()}"  # noqa: E501
+            system_call = f"psql {self.conninfo} -f {dump_file.absolute()}"
             result = os.system(system_call)
         if result != 0:
             raise DatabaseException(
@@ -825,11 +825,7 @@ class PostgresDatabase(AbstractDatabase):
             )  # noqa: E501
         now = datetime.now().strftime("%Y%m%d%H%M%S")
         output_location = output_directory / f"gene_norm_{now}.sql"
-        user = self.conn.info.user
-        host = self.conn.info.host
-        port = self.conn.info.port
-        database_name = self.conn.info.dbname
-        system_call = f"pg_dump {self.conninfo} -E UTF8 -f {output_location}"  # noqa: E501
+        system_call = f"pg_dump {self.conninfo} -E UTF8 -f {output_location}"
         result = os.system(system_call)
         if result != 0:
             raise DatabaseException(

--- a/src/gene/database/postgresql.py
+++ b/src/gene/database/postgresql.py
@@ -812,7 +812,7 @@ class PostgresDatabase(AbstractDatabase):
             result = os.system(system_call)
         if result != 0:
             raise DatabaseException(
-                f"System call '{result}' returned failing exit code."
+                f"System call '{system_call}' returned failing exit code {result}."
             )
 
     def export_db(self, output_directory: Path) -> None:
@@ -843,5 +843,5 @@ class PostgresDatabase(AbstractDatabase):
         result = os.system(system_call)
         if result != 0:
             raise DatabaseException(
-                f"System call '{system_call}' returned failing exit code."
+                f"System call '{system_call}' returned failing exit code {result}."
             )


### PR DESCRIPTION
Fixes two issues with the Postgres database class:

1. The error message when calling psql from `load_from_remote` wasn't very helpful, printing the return code rather than the system_call string.
2. `psql -W password` doesn't work that way, so I've changed it to always use the connection url when calling out to psql and pg_dump.