### PR TITLE
build: pin setuptools for 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,12 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 pg = ["psycopg[binary]"]
-etl = ["gffutils", "biocommons.seqrepo", "wags-tails>=0.1.1"]
+etl = [
+    "gffutils",
+    "biocommons.seqrepo",
+    "wags-tails>=0.1.1",
+    "setuptools",  # pinned for 3.12 because yoyo-migrations still uses pkg_resources
+]
 test = ["pytest>=6.0", "pytest-cov", "mock", "httpx"]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0"]
 docs = [


### PR DESCRIPTION
SeqRepo uses `yoyo-migrations`, a DB migration package, but they haven't updated their use of the deprecated `pkg_resources` module. For Python >= 3.12, you have to pin a `setuptools` dependency in the meantime.