### PR TITLE
feat!: remove `normalized_id` and leverage `MappableConcept.primaryCode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,23 @@ $ curl 'https://normalize.cancervariants.org/gene/normalize?q=BRAF' | python -m 
 {
     "query": "BRAF",
     "match_type": 100,
-    "normalized_id": "hgnc:1097",
     "gene": {
-        "type": "Gene",
+        "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1097"
+        "primaryCode": "hgnc:1097",
         "label": "BRAF",
-        "gene_id": "hgnc:1097",
-        "aliases": [
-            "BRAF1",
-            "B-RAF1",
-            "NS7",
-            "RAFB1",
-            "B-raf",
-            "BRAF-1"
+        "extensions": [
+            {
+                "name": "aliases",
+                "value": [
+                    "BRAF1",
+                    "B-RAF1",
+                    "NS7",
+                    "RAFB1",
+                    "B-raf",
+                    "BRAF-1"
+                ]
+            }
         ]
     }
     # ...
@@ -61,7 +65,7 @@ Or utilize the [Python API](https://gene-normalizer.readthedocs.io/latest/api/qu
 >>> from gene.query import QueryHandler
 >>> q = QueryHandler(create_db())
 >>> result = q.normalize("KRAS")
->>> result.normalized_id
+>>> result.gene.primaryCode
 'hgnc:6407'
 ```
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,9 +28,9 @@ A `public REST instance of the service <https://normalize.cancervariants.org/gen
 
    >>> import requests
    >>> result = requests.get("https://normalize.cancervariants.org/gene/normalize?q=braf").json()
-   >>> result["normalized_id"]
+   >>> result["gene"]["primaryCode"]
    'hgnc:1097'
-   >>> result["gene"]["aliases"]
+   >>> next(ext for ext in result["gene"]["extensions"] if ext["name"] == "aliases")["value"]
    ['B-raf', 'NS7', 'B-RAF1', 'BRAF-1', 'BRAF1', 'RAFB1']
 
 The Gene Normalizer can also be installed locally as a Python package for fast access:
@@ -41,10 +41,10 @@ The Gene Normalizer can also be installed locally as a Python package for fast a
     >>> from gene.database import create_db
     >>> q = QueryHandler(create_db())
     >>> result = q.normalize("BRAF")
-    >>> result.normalized_id
+    >>> result.gene.primaryCode.root
     'hgnc:1097'
-    >>> result.gene.aliases
-    ['NS7', 'RAFB1', 'B-raf', 'BRAF-1', 'BRAF1', 'B-RAF1']
+    >>> next(ext for ext in result.gene.extensions if ext.name == "aliases").value
+    ['B-raf', 'NS7', 'B-RAF1', 'BRAF-1', 'BRAF1', 'RAFB1']
 
 The Gene Normalizer was created to support the `Knowledgebase Integration Project <https://cancervariants.org/projects/integration/>`_ of the `Variant Interpretation for Cancer Consortium (VICC) <https://cancervariants.org/>`_. It is developed primarily by the `Wagner Lab <https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab>`_. Full source code is available on `GitHub <https://github.com/cancervariants/gene-normalization>`_.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -75,8 +75,8 @@ The beginning of the response to a GET request to http://localhost:5000/gene/nor
        "response_datetime": "2023-09-29 14:53:07.329897",
        "url": "https://github.com/cancervariants/gene-normalization"
      },
-     "normalized_id": "hgnc:1097",
      "gene": {
+       "primaryCode": "hgnc:1097",
        "id": "normalize.gene.hgnc:1097",
        "label": "BRAF",
 

--- a/docs/source/normalizing_data/normalization.rst
+++ b/docs/source/normalizing_data/normalization.rst
@@ -68,195 +68,202 @@ Normalized records are structured as `Genes <https://github.com/ga4gh/vrs/tree/2
 
   .. code-block:: json
 
-   {
-     "id": "normalize.gene.hgnc:1097",
-     "label": "BRAF",
-     "extensions": [
-       {
-         "name": "symbol_status",
-         "value": "approved"
-       },
-       {
-         "name": "approved_name",
-         "value": "B-Raf proto-oncogene, serine/threonine kinase"
-       },
-       {
-         "name": "strand",
-         "value": "-"
-       },
-       {
-         "name": "ensembl_locations",
-         "value": [
-           {
-             "id": "ga4gh:SL.fUv91vYrVHBMg-B_QW7UpOQj50g_49hb",
-             "digest": "fUv91vYrVHBMg-B_QW7UpOQj50g_49hb",
-             "type": "SequenceLocation",
-             "sequenceReference": {
-               "type": "SequenceReference",
-               "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
-             },
-             "start": 140719326,
-             "end": 140924929
-           }
-         ]
-       },
-       {
-         "name": "ncbi_locations",
-         "value": [
-           {
-             "id": "ga4gh:SL.0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
-             "digest": "0nPwKHYNnTmJ06G-gSmz8BEhB_NTp-0B",
-             "type": "SequenceLocation",
-             "sequenceReference": {
-               "type": "SequenceReference",
-               "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
-             },
-             "start": 140713327,
-             "end": 140924929
-           }
-         ]
-       },
-       {
-         "name": "hgnc_locus_type",
-         "value": "gene with protein product"
-       },
-       {
-         "name": "ncbi_gene_type",
-         "value": "protein-coding"
-       },
-       {
-         "name": "ensembl_biotype",
-         "value": "protein_coding"
-       }
-     ],
-     "mappings": [
-       {
-         "coding": {
-           "system": "ncbigene",
-           "code": "673"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ensembl",
-           "code": "ENSG00000157764"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "iuphar",
-           "code": "1943"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "omim",
-           "code": "164757"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ccds",
-           "code": "CCDS94218"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "pubmed",
-           "code": "1565476"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "vega",
-           "code": "OTTHUMG00000157457"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ucsc",
-           "code": "uc003vwc.5"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ena.embl",
-           "code": "M95712"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ccds",
-           "code": "CCDS87555"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ccds",
-           "code": "CCDS5863"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "cosmic",
-           "code": "BRAF"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "pubmed",
-           "code": "2284096"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "orphanet",
-           "code": "119066"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "refseq",
-           "code": "NM_004333"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "uniprot",
-           "code": "P15056"
-         },
-         "relation": "relatedMatch"
-       },
-       {
-         "coding": {
-           "system": "ccds",
-           "code": "CCDS94219"
-         },
-         "relation": "relatedMatch"
-       }
-     ],
-     "type": "Gene",
-     "aliases": [
-       "RAFB1",
-       "B-RAF1",
-       "BRAF1",
-       "BRAF-1",
-       "B-raf",
-       "NS7"
-     ]
-   }
+    {
+      "conceptType": "Gene",
+      "id": "normalize.gene.hgnc:1097",
+      "primaryCode": "hgnc:1097",
+      "label": "BRAF",
+      "mappings": [
+        {
+          "coding": {
+            "code": "1097",
+            "system": "hgnc"
+          },
+          "relation": "exactMatch"
+        },
+        {
+          "coding": {
+            "code": "673",
+            "system": "ncbigene"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "ENSG00000157764",
+            "system": "ensembl"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "CCDS5863",
+            "system": "ccds"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "1943",
+            "system": "iuphar"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "119066",
+            "system": "orphanet"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "BRAF",
+            "system": "cosmic"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "2284096",
+            "system": "pubmed"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "uc003vwc.5",
+            "system": "ucsc"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "164757",
+            "system": "omim"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "NM_004333",
+            "system": "refseq"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "CCDS87555",
+            "system": "ccds"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "P15056",
+            "system": "uniprot"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "M95712",
+            "system": "ena.embl"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "OTTHUMG00000157457",
+            "system": "vega"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "1565476",
+            "system": "pubmed"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "CCDS94219",
+            "system": "ccds"
+          },
+          "relation": "relatedMatch"
+        },
+        {
+          "coding": {
+            "code": "CCDS94218",
+            "system": "ccds"
+          },
+          "relation": "relatedMatch"
+        }
+      ],
+      "extensions": [
+        {
+          "name": "aliases",
+          "value": [
+            "BRAF1",
+            "BRAF-1",
+            "RAFB1",
+            "NS7",
+            "B-RAF1",
+            "B-raf"
+          ]
+        },
+        {
+          "name": "approved_name",
+          "value": "B-Raf proto-oncogene, serine/threonine kinase"
+        },
+        {
+          "name": "ensembl_locations",
+          "value": [
+            {
+              "type": "SequenceLocation",
+              "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+              },
+              "start": 140719326,
+              "end": 140924929
+            }
+          ]
+        },
+        {
+          "name": "ncbi_locations",
+          "value": [
+            {
+              "type": "SequenceLocation",
+              "sequenceReference": {
+                "type": "SequenceReference",
+                "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+              },
+              "start": 140713327,
+              "end": 140924929
+            }
+          ]
+        },
+        {
+          "name": "ncbi_gene_type",
+          "value": "protein-coding"
+        },
+        {
+          "name": "hgnc_locus_type",
+          "value": "gene with protein product"
+        },
+        {
+          "name": "ensembl_biotype",
+          "value": "protein_coding"
+        },
+        {
+          "name": "strand",
+          "value": "-"
+        },
+        {
+          "name": "symbol_status",
+          "value": "approved"
+        }
+      ]
+    }

--- a/src/gene/schemas.py
+++ b/src/gene/schemas.py
@@ -300,7 +300,6 @@ class BaseNormalizationService(BaseModel):
 class NormalizeService(BaseNormalizationService):
     """Define model for returning normalized concept."""
 
-    normalized_id: str | None = None
     gene: MappableConcept | None = None
     source_meta_: dict[SourceName, SourceMeta] = {}
 
@@ -310,12 +309,16 @@ class NormalizeService(BaseNormalizationService):
                 "query": "BRAF",
                 "warnings": [],
                 "match_type": 100,
-                "normalized_id": "hgnc:1037",
                 "gene": {
-                    "type": "Gene",
+                    "conceptType": "Gene",
                     "id": "normalize.gene.hgnc:1097",
+                    "primaryCode": "hgnc:1097",
                     "label": "BRAF",
                     "mappings": [
+                        {
+                            "coding": {"code": "1097", "system": "hgnc"},
+                            "relation": "exactMatch",
+                        },
                         {
                             "coding": {"code": "673", "system": "ncbigene"},
                             "relation": "relatedMatch",
@@ -376,17 +379,67 @@ class NormalizeService(BaseNormalizationService):
                             "coding": {"code": "1565476", "system": "pubmed"},
                             "relation": "relatedMatch",
                         },
+                        {
+                            "coding": {"code": "CCDS94219", "system": "ccds"},
+                            "relation": "relatedMatch",
+                        },
+                        {
+                            "coding": {"code": "CCDS94218", "system": "ccds"},
+                            "relation": "relatedMatch",
+                        },
                     ],
-                    "aliases": ["BRAF1", "RAFB1", "B-raf", "NS7", "B-RAF1"],
                     "extensions": [
+                        {
+                            "name": "aliases",
+                            "value": [
+                                "BRAF1",
+                                "BRAF-1",
+                                "RAFB1",
+                                "NS7",
+                                "B-RAF1",
+                                "B-raf",
+                            ],
+                        },
                         {
                             "name": "approved_name",
                             "value": "B-Raf proto-oncogene, serine/threonine kinase",
                         },
                         {
-                            "name": "symbol_status",
-                            "value": "approved",
+                            "name": "ensembl_locations",
+                            "value": [
+                                {
+                                    "type": "SequenceLocation",
+                                    "sequenceReference": {
+                                        "type": "SequenceReference",
+                                        "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                                    },
+                                    "start": 140719326,
+                                    "end": 140924929,
+                                }
+                            ],
                         },
+                        {
+                            "name": "ncbi_locations",
+                            "value": [
+                                {
+                                    "type": "SequenceLocation",
+                                    "sequenceReference": {
+                                        "type": "SequenceReference",
+                                        "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                                    },
+                                    "start": 140713327,
+                                    "end": 140924929,
+                                }
+                            ],
+                        },
+                        {"name": "ncbi_gene_type", "value": "protein-coding"},
+                        {
+                            "name": "hgnc_locus_type",
+                            "value": "gene with protein product",
+                        },
+                        {"name": "ensembl_biotype", "value": "protein_coding"},
+                        {"name": "strand", "value": "-"},
+                        {"name": "symbol_status", "value": "approved"},
                     ],
                 },
                 "source_meta_": {

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -34,7 +34,7 @@ def test_normalize(api_client):
     """Test /normalize endpoint."""
     response = api_client.get("/gene/normalize?q=braf")
     assert response.status_code == 200
-    assert response.json()["normalized_id"] == "hgnc:1097"
+    assert response.json()["gene"]["primaryCode"] == "hgnc:1097"
 
 
 def test_normalize_unmerged(api_client):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -34,8 +34,13 @@ def normalized_ache():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:108",
+        "primaryCode": "hgnc:108",
         "label": "ACHE",
         "mappings": [
+            {
+                "coding": {"code": "108", "system": "hgnc"},
+                "relation": "exactMatch",
+            },
             {
                 "coding": {"code": "ENSG00000087085", "system": "ensembl"},
                 "relation": "relatedMatch",
@@ -143,8 +148,10 @@ def normalized_braf():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1097",
+        "primaryCode": "hgnc:1097",
         "label": "BRAF",
         "mappings": [
+            {"coding": {"code": "1097", "system": "hgnc"}, "relation": "exactMatch"},
             {
                 "coding": {"code": "673", "system": "ncbigene"},
                 "relation": "relatedMatch",
@@ -270,8 +277,13 @@ def normalized_abl1():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:76",
+        "primaryCode": "hgnc:76",
         "label": "ABL1",
         "mappings": [
+            {
+                "coding": {"code": "76", "system": "hgnc"},
+                "relation": "exactMatch",
+            },
             {
                 "coding": {"code": "ENSG00000097007", "system": "ensembl"},
                 "relation": "relatedMatch",
@@ -405,8 +417,13 @@ def normalized_p150():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1910",
+        "primaryCode": "hgnc:1910",
         "label": "CHAF1A",
         "mappings": [
+            {
+                "coding": {"code": "1910", "system": "hgnc"},
+                "relation": "exactMatch",
+            },
             {
                 "coding": {"code": "ENSG00000167670", "system": "ensembl"},
                 "relation": "relatedMatch",
@@ -518,6 +535,13 @@ def normalized_loc_653303():
     params = {
         "conceptType": "Gene",
         "label": "LOC653303",
+        "primaryCode": "ncbigene:653303",
+        "mappings": [
+            {
+                "coding": {"code": "653303", "system": "ncbigene"},
+                "relation": "exactMatch",
+            },
+        ],
         "extensions": [
             {
                 "name": "aliases",
@@ -795,8 +819,13 @@ def normalized_ifnr():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:5447",
+        "primaryCode": "hgnc:5447",
         "label": "IFNR",
         "mappings": [
+            {
+                "coding": {"code": "5447", "system": "hgnc"},
+                "relation": "exactMatch",
+            },
             {
                 "coding": {"code": "3466", "system": "ncbigene"},
                 "relation": "relatedMatch",
@@ -874,7 +903,7 @@ def compare_normalize_resp(
     assert resp.query == expected_query
     compare_warnings(resp.warnings, expected_warnings)
     assert resp.match_type == expected_match_type
-    assert resp.normalized_id == expected_gene.id.split("normalize.gene.")[-1]
+    assert resp.gene.primaryCode.root == expected_gene.id.split("normalize.gene.")[-1]
     compare_gene(expected_gene, resp.gene)
     if not expected_source_meta:
         assert resp.source_meta_ == {}


### PR DESCRIPTION
close #380

* also updates mappigns to include exactMatch relation for merged concept identifier

Comment:
In the future, we may want to consider also updating our `ConceptMappings` to leverage uri/urls since they are preferred 