### PR TITLE
cicd: update precommit + hooks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hook:
+        cmd:
           - "end-of-file-fixer"
           - "trailing-whitespace"
           - "mixed-line-ending"
@@ -82,7 +82,7 @@ jobs:
 
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: ${{ matrix.hook }} --all-files
+          extra_args: ${{ matrix.cmd }} --all-files
 
   docs:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0  # pre-commit-hooks version
+  rev: v5.0.0  # pre-commit-hooks version
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=1500']
@@ -17,4 +17,4 @@ repos:
   hooks:
     - id: ruff
     - id: ruff-format
-minimum_pre_commit_version: 3.7.1
+minimum_pre_commit_version: 4.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ etl = [
     "setuptools",  # pinned for 3.12 because yoyo-migrations still uses pkg_resources
 ]
 tests = ["pytest>=6.0", "pytest-cov", "mock", "httpx", "deepdiff"]
-dev = ["pre-commit>=3.7.1", "ruff==0.8.6"]
+dev = ["pre-commit>=4.0.1", "ruff==0.8.6"]
 docs = [
     "sphinx==6.1.3",
     "sphinx-autodoc-typehints==1.22.0",


### PR DESCRIPTION
catch up to https://github.com/GenomicMedLab/software-templates/releases/tag/2025.01.08