### PR TITLE
feat!: Update to include primaryCoding attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ $ curl 'https://normalize.cancervariants.org/gene/normalize?q=BRAF' | python -m 
     "gene": {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1097"
-        "primaryCode": "hgnc:1097",
+        "primaryCoding": {
+            "id": "hgnc:1097",
+            "code": "HGNC:1097",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "BRAF",
         "extensions": [
             {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Or utilize the [Python API](https://gene-normalizer.readthedocs.io/latest/api/qu
 >>> from gene.query import QueryHandler
 >>> q = QueryHandler(create_db())
 >>> result = q.normalize("KRAS")
->>> result.gene.primaryCode
+>>> result.gene.primaryCoding.id
 'hgnc:6407'
 ```
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ A `public REST instance of the service <https://normalize.cancervariants.org/gen
 
    >>> import requests
    >>> result = requests.get("https://normalize.cancervariants.org/gene/normalize?q=braf").json()
-   >>> result["gene"]["primaryCode"]
+   >>> result["gene"]["primaryCoding"]["id"]
    'hgnc:1097'
    >>> next(ext for ext in result["gene"]["extensions"] if ext["name"] == "aliases")["value"]
    ['B-raf', 'NS7', 'B-RAF1', 'BRAF-1', 'BRAF1', 'RAFB1']
@@ -41,7 +41,7 @@ The Gene Normalizer can also be installed locally as a Python package for fast a
     >>> from gene.database import create_db
     >>> q = QueryHandler(create_db())
     >>> result = q.normalize("BRAF")
-    >>> result.gene.primaryCode.root
+    >>> result.gene.primaryCoding.id
     'hgnc:1097'
     >>> next(ext for ext in result.gene.extensions if ext.name == "aliases").value
     ['B-raf', 'NS7', 'B-RAF1', 'BRAF-1', 'BRAF1', 'RAFB1']

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -76,8 +76,12 @@ The beginning of the response to a GET request to http://localhost:5000/gene/nor
        "url": "https://github.com/cancervariants/gene-normalization"
      },
      "gene": {
-       "primaryCode": "hgnc:1097",
        "id": "normalize.gene.hgnc:1097",
+       "primaryCoding": {
+            "id": "hgnc:1097",
+            "code": "HGNC:1097",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
        "name": "BRAF",
 
        ...

--- a/docs/source/normalizing_data/normalization.rst
+++ b/docs/source/normalizing_data/normalization.rst
@@ -71,16 +71,13 @@ Normalized records are structured as `Genes <https://github.com/ga4gh/vrs/tree/2
     {
       "conceptType": "Gene",
       "id": "normalize.gene.hgnc:1097",
-      "primaryCode": "hgnc:1097",
+      "primaryCoding": {
+            "id": "hgnc:1097",
+            "code": "HGNC:1097",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
       "name": "BRAF",
       "mappings": [
-          {
-              "coding": {
-                  "code": "HGNC:1097",
-                  "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-              },
-              "relation": "exactMatch",
-          },
           {
               "coding": {
                   "id": "ncbigene:673",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "click",
     "boto3",
-    "ga4gh.vrs==2.0.0a14",
+    "ga4gh.vrs~=2.0.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "click",
     "boto3",
-    "ga4gh.vrs~=2.0.0",
+    "ga4gh.vrs~=2.*",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "click",
     "boto3",
-    "ga4gh.vrs~=2.*",
+    "ga4gh.vrs==2.*",
 ]
 dynamic = ["version"]
 

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -432,9 +432,14 @@ class QueryHandler:
                 relation=relation,
             )
 
+        source = NamespacePrefix(record["concept_id"].split(":")[0])
         gene_obj = MappableConcept(
             id=f"normalize.gene.{record['concept_id']}",
-            primaryCode=code(root=record["concept_id"]),
+            primaryCoding = Coding(
+                id=record["concept_id"],
+                code=code(record["concept_id"]),
+                system=NAMESPACE_TO_SYSTEM_URI[source]
+            ),
             name=record["symbol"],
             conceptType="Gene",
         )
@@ -442,7 +447,7 @@ class QueryHandler:
         xrefs = [record["concept_id"], *record.get("xrefs", [])]
         gene_obj.mappings = [
             _get_concept_mapping(xref_id, relation=Relation.EXACT_MATCH)
-            for xref_id in xrefs
+            for xref_id in xrefs if xref_id != record["concept_id"]
         ]
 
         associated_with = record.get("associated_with", [])

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -350,6 +350,9 @@ class QueryHandler:
             if ns in PREFIX_LOOKUP:
                 sources.append(PREFIX_LOOKUP[ns])
 
+        # Add metadata for primaryCoding id
+        sources.append(PREFIX_LOOKUP[gene.primaryCoding.id.split(":")[0]])
+
         for src in sources:
             if src not in sources_meta:
                 _source_meta = self.db.get_source_metadata(src)

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -432,14 +432,9 @@ class QueryHandler:
                 relation=relation,
             )
 
-        source = NamespacePrefix(record["concept_id"].split(":")[0])
         gene_obj = MappableConcept(
             id=f"normalize.gene.{record['concept_id']}",
-            primaryCoding=Coding(
-                id=record["concept_id"],
-                code=code(record["concept_id"].upper()),
-                system=NAMESPACE_TO_SYSTEM_URI[source],
-            ),
+            primaryCoding=_get_concept_mapping(record["concept_id"]).coding,
             name=record["symbol"],
             conceptType="Gene",
         )

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -409,6 +409,8 @@ class QueryHandler:
 
             :param concept_id: A lowercase concept identifier represented as a curie
             :return: Coding object for identifier
+            :raises ValueError: If source of concept ID is not a valid
+                ``NamespacePrefix``
             """
             source, source_code = concept_id.split(":")
 
@@ -428,16 +430,16 @@ class QueryHandler:
             )
 
         def _get_concept_mapping(
-            coding_obj: Coding, relation: Relation = Relation.RELATED_MATCH
+            concept_id: str, relation: Relation = Relation.RELATED_MATCH
         ) -> ConceptMapping:
             """Get concept mapping for Coding object
 
-            :param coding: A Coding object
+            :param concept_id: A lowercase concept identifier represented as a curie
             :param relation: SKOS mapping relationship, default is relatedMatch
             :return: Concept mapping for identifier
             """
             return ConceptMapping(
-                coding=coding_obj,
+                coding=_get_coding_object(concept_id),
                 relation=relation,
             )
 
@@ -450,18 +452,14 @@ class QueryHandler:
 
         xrefs = [record["concept_id"], *record.get("xrefs", [])]
         gene_obj.mappings = [
-            _get_concept_mapping(
-                _get_coding_object(xref_id), relation=Relation.EXACT_MATCH
-            )
+            _get_concept_mapping(xref_id, relation=Relation.EXACT_MATCH)
             for xref_id in xrefs
             if xref_id != record["concept_id"]
         ]
 
         associated_with = record.get("associated_with", [])
         gene_obj.mappings.extend(
-            _get_concept_mapping(
-                _get_coding_object(associated_with_id), relation=Relation.RELATED_MATCH
-            )
+            _get_concept_mapping(associated_with_id, relation=Relation.RELATED_MATCH)
             for associated_with_id in associated_with
         )
 

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -435,10 +435,10 @@ class QueryHandler:
         source = NamespacePrefix(record["concept_id"].split(":")[0])
         gene_obj = MappableConcept(
             id=f"normalize.gene.{record['concept_id']}",
-            primaryCoding = Coding(
+            primaryCoding=Coding(
                 id=record["concept_id"],
                 code=code(record["concept_id"]),
-                system=NAMESPACE_TO_SYSTEM_URI[source]
+                system=NAMESPACE_TO_SYSTEM_URI[source],
             ),
             name=record["symbol"],
             conceptType="Gene",
@@ -447,7 +447,8 @@ class QueryHandler:
         xrefs = [record["concept_id"], *record.get("xrefs", [])]
         gene_obj.mappings = [
             _get_concept_mapping(xref_id, relation=Relation.EXACT_MATCH)
-            for xref_id in xrefs if xref_id != record["concept_id"]
+            for xref_id in xrefs
+            if xref_id != record["concept_id"]
         ]
 
         associated_with = record.get("associated_with", [])

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -437,7 +437,7 @@ class QueryHandler:
             id=f"normalize.gene.{record['concept_id']}",
             primaryCoding=Coding(
                 id=record["concept_id"],
-                code=code(record["concept_id"]),
+                code=code(record["concept_id"].upper()),
                 system=NAMESPACE_TO_SYSTEM_URI[source],
             ),
             name=record["symbol"],

--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -573,7 +573,7 @@ class QueryHandler:
         >>> from gene.database import create_db
         >>> q = QueryHandler(create_db())
         >>> result = q.normalize("BRAF")
-        >>> result.gene.primaryCode.root
+        >>> result.gene.primaryCoding.id
         'hgnc:1097'
         >>> next(ext for ext in result.gene.extensions if ext.name == "aliases").value
         ['BRAF1', 'RAFB1', 'B-raf', 'NS7', 'B-RAF1']

--- a/src/gene/schemas.py
+++ b/src/gene/schemas.py
@@ -351,7 +351,7 @@ class NormalizeService(BaseNormalizationService):
                     "primaryCoding": {
                         "id": "hgnc:1097",
                         "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                        "code": "hgnc:1097",
+                        "code": "HGNC:1097",
                     },
                     "name": "BRAF",
                     "mappings": [

--- a/src/gene/schemas.py
+++ b/src/gene/schemas.py
@@ -348,17 +348,13 @@ class NormalizeService(BaseNormalizationService):
                 "gene": {
                     "conceptType": "Gene",
                     "id": "normalize.gene.hgnc:1097",
-                    "primaryCode": "hgnc:1097",
+                    "primaryCoding": {
+                        "id": "hgnc:1097",
+                        "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+                        "code": "hgnc:1097"
+                    },
                     "name": "BRAF",
                     "mappings": [
-                        {
-                            "coding": {
-                                "id": "hgnc:1097",
-                                "code": "HGNC:1097",
-                                "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                            },
-                            "relation": "exactMatch",
-                        },
                         {
                             "coding": {
                                 "id": "ncbigene:673",

--- a/src/gene/schemas.py
+++ b/src/gene/schemas.py
@@ -351,7 +351,7 @@ class NormalizeService(BaseNormalizationService):
                     "primaryCoding": {
                         "id": "hgnc:1097",
                         "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                        "code": "hgnc:1097"
+                        "code": "hgnc:1097",
                     },
                     "name": "BRAF",
                     "mappings": [

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -35,6 +35,11 @@ def test_normalize(api_client):
     response = api_client.get("/gene/normalize?q=braf")
     assert response.status_code == 200
     assert response.json()["gene"]["primaryCoding"]["id"] == "hgnc:1097"
+    assert response.json()["gene"]["primaryCoding"]["code"] == "HGNC:1097"
+    assert (
+        response.json()["gene"]["primaryCoding"]["system"]
+        == "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/"
+    )
 
 
 def test_normalize_unmerged(api_client):

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -34,12 +34,11 @@ def test_normalize(api_client):
     """Test /normalize endpoint."""
     response = api_client.get("/gene/normalize?q=braf")
     assert response.status_code == 200
-    assert response.json()["gene"]["primaryCoding"]["id"] == "hgnc:1097"
-    assert response.json()["gene"]["primaryCoding"]["code"] == "HGNC:1097"
-    assert (
-        response.json()["gene"]["primaryCoding"]["system"]
-        == "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/"
-    )
+    assert response.json()["gene"]["primaryCoding"] == {
+        "id": "hgnc:1097",
+        "code": "HGNC:1097",
+        "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+    }
 
 
 def test_normalize_unmerged(api_client):

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -34,7 +34,7 @@ def test_normalize(api_client):
     """Test /normalize endpoint."""
     response = api_client.get("/gene/normalize?q=braf")
     assert response.status_code == 200
-    assert response.json()["gene"]["primaryCode"] == "hgnc:1097"
+    assert response.json()["gene"]["primaryCoding"]["id"] == "hgnc:1097"
 
 
 def test_normalize_unmerged(api_client):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -36,7 +36,7 @@ def normalized_ache():
         "id": "normalize.gene.hgnc:108",
         "primaryCoding": {
             "id": "hgnc:108",
-            "code": "hgnc:108",
+            "code": "HGNC:108",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
         },
         "name": "ACHE",
@@ -178,7 +178,7 @@ def normalized_braf():
         "id": "normalize.gene.hgnc:1097",
         "primaryCoding": {
             "id": "hgnc:1097",
-            "code": "hgnc:1097",
+            "code": "HGNC:1097",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
         },
         "name": "BRAF",
@@ -346,7 +346,7 @@ def normalized_abl1():
         "id": "normalize.gene.hgnc:76",
         "primaryCoding": {
             "id": "hgnc:76",
-            "code": "hgnc:76",
+            "code": "HGNC:76",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
         },
         "name": "ABL1",
@@ -530,7 +530,7 @@ def normalized_p150():
         "id": "normalize.gene.hgnc:1910",
         "primaryCoding": {
             "id": "hgnc:1910",
-            "code": "hgnc:1910",
+            "code": "HGNC:1910",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
         },
         "name": "CHAF1A",
@@ -688,7 +688,7 @@ def normalized_loc_653303():
         "name": "LOC653303",
         "primaryCoding": {
             "id": "ncbigene:653303",
-            "code": "ncbigene:653303",
+            "code": "NCBIGENE:653303",
             "system": "https://www.ncbi.nlm.nih.gov/gene/",
         },
         "mappings": [],
@@ -968,7 +968,7 @@ def normalized_ifnr():
         "id": "normalize.gene.hgnc:5447",
         "primaryCoding": {
             "id": "hgnc:5447",
-            "code": "hgnc:5447",
+            "code": "HGNC:5447",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
         },
         "name": "IFNR",

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -34,17 +34,13 @@ def normalized_ache():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:108",
-        "primaryCode": "hgnc:108",
+        "primaryCoding": {
+            "id": "hgnc:108",
+            "code": "hgnc:108",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "ACHE",
         "mappings": [
-            {
-                "coding": {
-                    "id": "hgnc:108",
-                    "code": "HGNC:108",
-                    "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                },
-                "relation": "exactMatch",
-            },
             {
                 "coding": {
                     "id": "ensembl:ENSG00000087085",
@@ -180,17 +176,13 @@ def normalized_braf():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1097",
-        "primaryCode": "hgnc:1097",
+        "primaryCoding": {
+            "id": "hgnc:1097",
+            "code": "hgnc:1097",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "BRAF",
         "mappings": [
-            {
-                "coding": {
-                    "id": "hgnc:1097",
-                    "code": "HGNC:1097",
-                    "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                },
-                "relation": "exactMatch",
-            },
             {
                 "coding": {
                     "id": "ncbigene:673",
@@ -352,17 +344,13 @@ def normalized_abl1():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:76",
-        "primaryCode": "hgnc:76",
+        "primaryCoding":  {
+            "id": "hgnc:76",
+            "code": "hgnc:76",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "ABL1",
         "mappings": [
-            {
-                "coding": {
-                    "id": "hgnc:76",
-                    "code": "HGNC:76",
-                    "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                },
-                "relation": "exactMatch",
-            },
             {
                 "coding": {
                     "id": "ensembl:ENSG00000097007",
@@ -540,17 +528,13 @@ def normalized_p150():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:1910",
-        "primaryCode": "hgnc:1910",
+        "primaryCoding": {
+            "id": "hgnc:1910",
+            "code": "hgnc:1910",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "CHAF1A",
         "mappings": [
-            {
-                "coding": {
-                    "id": "hgnc:1910",
-                    "code": "HGNC:1910",
-                    "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                },
-                "relation": "exactMatch",
-            },
             {
                 "coding": {
                     "id": "ensembl:ENSG00000167670",
@@ -702,17 +686,12 @@ def normalized_loc_653303():
     params = {
         "conceptType": "Gene",
         "name": "LOC653303",
-        "primaryCode": "ncbigene:653303",
-        "mappings": [
-            {
-                "coding": {
-                    "id": "ncbigene:653303",
-                    "code": "653303",
-                    "system": "https://www.ncbi.nlm.nih.gov/gene/",
-                },
-                "relation": "exactMatch",
-            },
-        ],
+        "primaryCoding":  {
+            "id": "ncbigene:653303",
+            "code": "ncbigene:653303",
+            "system": "https://www.ncbi.nlm.nih.gov/gene/",
+        },
+        "mappings": [],
         "extensions": [
             {
                 "name": "aliases",
@@ -987,17 +966,13 @@ def normalized_ifnr():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:5447",
-        "primaryCode": "hgnc:5447",
+        "primaryCoding": {
+            "id": "hgnc:5447",
+            "code": "hgnc:5447",
+            "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
+        },
         "name": "IFNR",
         "mappings": [
-            {
-                "coding": {
-                    "id": "hgnc:5447",
-                    "code": "HGNC:5447",
-                    "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
-                },
-                "relation": "exactMatch",
-            },
             {
                 "coding": {
                     "id": "ncbigene:3466",
@@ -1091,7 +1066,7 @@ def compare_normalize_resp(
     assert resp.query == expected_query
     compare_warnings(resp.warnings, expected_warnings)
     assert resp.match_type == expected_match_type
-    assert resp.gene.primaryCode.root == expected_gene.id.split("normalize.gene.")[-1]
+    assert resp.gene.primaryCoding.id == expected_gene.id.split("normalize.gene.")[-1]
     compare_gene(expected_gene, resp.gene)
     if not expected_source_meta:
         assert resp.source_meta_ == {}
@@ -1163,8 +1138,7 @@ def compare_gene(test, actual):
                 loc_id = loc.pop("id")
                 loc_digest = loc.pop("digest")
                 assert loc_id.split("ga4gh:SL.")[-1] == loc_digest
-
-    diff = DeepDiff(actual, test, ignore_order=True)
+    diff = DeepDiff(test, actual, ignore_order=True)
     assert diff == {}, test.id
 
 
@@ -1235,6 +1209,7 @@ def test_ache_query(query_handler, num_sources, normalized_ache, source_meta):
     # Normalize
     q = "ACHE"
     resp = query_handler.normalize(q)
+    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_ache, expected_source_meta=source_meta
     )
@@ -1333,6 +1308,7 @@ def test_braf_query(query_handler, num_sources, normalized_braf, source_meta):
     # Normalize
     q = "BRAF"
     resp = query_handler.normalize(q)
+    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_braf, expected_source_meta=source_meta
     )
@@ -1411,6 +1387,7 @@ def test_abl1_query(query_handler, num_sources, normalized_abl1, source_meta):
     # Normalize
     q = "ABL1"
     resp = query_handler.normalize(q)
+    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_abl1, expected_source_meta=source_meta
     )
@@ -1490,6 +1467,7 @@ def test_multiple_norm_concepts(query_handler, normalized_p150, source_meta):
     """Tests where more than one normalized concept is found."""
     q = "P150"
     resp = query_handler.normalize(q)
+    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     expected_warnings = [
         {
             "multiple_normalized_concepts_found": [
@@ -1522,7 +1500,6 @@ def test_normalize_single_entry(query_handler, normalized_loc_653303):
         q,
         MatchType.SYMBOL,
         normalized_loc_653303,
-        expected_source_meta=[SourceName.NCBI],
     )
 
 
@@ -1537,7 +1514,7 @@ def test_normalize_no_locations(query_handler, normalized_ifnr):
         q,
         MatchType.SYMBOL,
         normalized_ifnr,
-        expected_source_meta=[SourceName.HGNC, SourceName.NCBI],
+        expected_source_meta=[SourceName.NCBI],
     )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1209,7 +1209,6 @@ def test_ache_query(query_handler, num_sources, normalized_ache, source_meta):
     # Normalize
     q = "ACHE"
     resp = query_handler.normalize(q)
-    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_ache, expected_source_meta=source_meta
     )
@@ -1308,7 +1307,6 @@ def test_braf_query(query_handler, num_sources, normalized_braf, source_meta):
     # Normalize
     q = "BRAF"
     resp = query_handler.normalize(q)
-    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_braf, expected_source_meta=source_meta
     )
@@ -1387,7 +1385,6 @@ def test_abl1_query(query_handler, num_sources, normalized_abl1, source_meta):
     # Normalize
     q = "ABL1"
     resp = query_handler.normalize(q)
-    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     compare_normalize_resp(
         resp, q, MatchType.SYMBOL, normalized_abl1, expected_source_meta=source_meta
     )
@@ -1467,7 +1464,6 @@ def test_multiple_norm_concepts(query_handler, normalized_p150, source_meta):
     """Tests where more than one normalized concept is found."""
     q = "P150"
     resp = query_handler.normalize(q)
-    source_meta = [SourceName.ENSEMBL, SourceName.NCBI]
     expected_warnings = [
         {
             "multiple_normalized_concepts_found": [
@@ -1500,6 +1496,7 @@ def test_normalize_single_entry(query_handler, normalized_loc_653303):
         q,
         MatchType.SYMBOL,
         normalized_loc_653303,
+        expected_source_meta=[SourceName.NCBI],
     )
 
 
@@ -1514,7 +1511,7 @@ def test_normalize_no_locations(query_handler, normalized_ifnr):
         q,
         MatchType.SYMBOL,
         normalized_ifnr,
-        expected_source_meta=[SourceName.NCBI],
+        expected_source_meta=[SourceName.HGNC, SourceName.NCBI],
     )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -688,7 +688,7 @@ def normalized_loc_653303():
         "name": "LOC653303",
         "primaryCoding": {
             "id": "ncbigene:653303",
-            "code": "NCBIGENE:653303",
+            "code": "653303",
             "system": "https://www.ncbi.nlm.nih.gov/gene/",
         },
         "mappings": [],

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -344,7 +344,7 @@ def normalized_abl1():
     params = {
         "conceptType": "Gene",
         "id": "normalize.gene.hgnc:76",
-        "primaryCoding":  {
+        "primaryCoding": {
             "id": "hgnc:76",
             "code": "hgnc:76",
             "system": "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
@@ -686,7 +686,7 @@ def normalized_loc_653303():
     params = {
         "conceptType": "Gene",
         "name": "LOC653303",
-        "primaryCoding":  {
+        "primaryCoding": {
             "id": "ncbigene:653303",
             "code": "ncbigene:653303",
             "system": "https://www.ncbi.nlm.nih.gov/gene/",


### PR DESCRIPTION
closes #404 

@korikuzma @jsstevenson Notes:
- This PR replaces the `primaryCode` attribute with `primaryCoding`
- I had trouble getting the `code` attribute to all uppercase as shown in the issue [example](https://github.com/cancervariants/gene-normalization/issues/404). Should this attribute be uppercase?
- I left the `UnmergedNormalizationService` class the same. Do we want to update this?