### PR TITLE
build: bump wags-tails to latest version (v0.3.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pg = ["psycopg[binary]"]
 etl = [
     "gffutils",
     "biocommons.seqrepo",
-    "wags-tails~=0.2.1",
+    "wags-tails~=0.3.2",
     "setuptools",  # pinned for 3.12 because yoyo-migrations still uses pkg_resources
 ]
 tests = ["pytest>=6.0", "pytest-cov", "mock", "httpx", "deepdiff"]


### PR DESCRIPTION
I'm working on updating MetaKB to the latest GKS specs and was getting dependency conflicts