### PR TITLE
 feat: optionally exclude non-protein coding genes from mapping dump 

### DIFF
--- a/src/gene/cli.py
+++ b/src/gene/cli.py
@@ -274,7 +274,7 @@ def update(
 )
 @click.option(
     "--protein-coding-only",
-    help="Whether to constrain mappings to just include genes annotated as protein-coding",
+    help="Whether to constrain mappings to only include genes annotated as protein-coding",
     is_flag=True,
 )
 def dump_mappings(

--- a/src/gene/cli.py
+++ b/src/gene/cli.py
@@ -1,5 +1,6 @@
 """Provides a CLI util to make updates to normalizer database."""
 
+import datetime
 import json
 import logging
 import os
@@ -271,8 +272,16 @@ def update(
     help="Output location to write to",
     type=click.Path(path_type=Path),
 )
+@click.option(
+    "--protein-coding-only",
+    help="Whether to constrain mappings to just include genes annotated as protein-coding",
+    is_flag=True,
+)
 def dump_mappings(
-    db_url: str, scope: RecordType | SourceName, outfile: Path | None
+    db_url: str,
+    scope: RecordType | SourceName,
+    outfile: Path | None,
+    protein_coding_only: bool,
 ) -> None:
     """Produce JSON Lines file dump of concept referents (e.g. name/label, alias, xrefs) and the associated concept.
 
@@ -284,12 +293,23 @@ def dump_mappings(
     Or to the identity records of a specific source:
 
         $ gene-normalizer dump-mappings --scope ncit
+
+    The first object in the .jsonl file will contain metadata about parameters used to create the document.
     """
     db = create_db(db_url, False)
     if outfile is None:
         outfile = Path() / "gene_normalizer_mappings.jsonl"
     with outfile.open("w") as f:
-        for mapping in get_term_mappings(db, scope):
+        meta = {
+            "created_at": datetime.datetime.now(tz=datetime.UTC).isoformat(),
+            "scope": scope,
+            "protein_coding_only": protein_coding_only,
+        }
+        f.write(json.dumps(meta))
+        f.write("\n")
+        for mapping in get_term_mappings(
+            db, scope, protein_coding_only=protein_coding_only
+        ):
             f.write(json.dumps(mapping))
             f.write("\n")
 

--- a/src/gene/cli.py
+++ b/src/gene/cli.py
@@ -301,6 +301,7 @@ def dump_mappings(
         outfile = Path() / "gene_normalizer_mappings.jsonl"
     with outfile.open("w") as f:
         meta = {
+            "type": "meta",
             "created_at": datetime.datetime.now(tz=datetime.UTC).isoformat(),
             "scope": scope,
             "protein_coding_only": protein_coding_only,

--- a/src/gene/utils.py
+++ b/src/gene/utils.py
@@ -57,11 +57,29 @@ def get_term_mappings(
     for record in database.get_all_records(record_type=record_type):
         if src_name and record["src_name"] != src_name:
             continue
-        if (
-            protein_coding_only
-            and record.get("gene_type") not in protein_coding_gene_types
+        if protein_coding_only and (
+            (
+                record_type == RecordType.IDENTITY
+                and record.get("gene_type") not in protein_coding_gene_types
+            )
+            or (
+                record_type == RecordType.MERGER
+                and (
+                    "ensembl_biotype" not in record
+                    or record.get("ensembl_biotype") == "protein_coding"
+                )
+                and (
+                    "ncbi_gene_type" not in record
+                    or record["ncbi_gene_type"] == "protein_coding"
+                )
+                and (
+                    "hgnc_locus_type" not in record
+                    or record["hgnc_locus_type"] == "gene with protein product"
+                )
+            )
         ):
             continue
+
         yield {
             "concept_id": record["concept_id"],
             "symbol": record["symbol"],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -264,6 +264,15 @@ def test_db(null_database_class):
                     "xrefs": ["ncbigene:1956", "ensembl:ENSG00000146648"],
                     "item_type": "merger",
                 },
+                {
+                    "concept_id": "ncbigene:3378",
+                    "label": "inflammatory bowel disease 2",
+                    "gene_type": "unknown",
+                    "associated_with": ["omim:601458"],
+                    "symbol": "IBD2",
+                    "src_name": "NCBI",
+                    "item_type": "identity",
+                },
             ],
         }
     )
@@ -375,6 +384,16 @@ def test_get_term_mappings_merger(test_db: AbstractDatabase):
                 "ensembl:ENSG00000146648",
             ],
         },
+        {
+            "aliases": [],
+            "concept_id": "ncbigene:3378",
+            "label": "inflammatory bowel disease 2",
+            "previous_symbols": [],
+            "symbol": "IBD2",
+            "xrefs": [
+                "omim:601458",
+            ],
+        },
     ]
     diff = DeepDiff(fixture, results, ignore_order=True)
     assert diff == {}
@@ -386,3 +405,9 @@ def test_get_term_mappings_protein_coding_only(test_db: AbstractDatabase):
     )
     assert len(results) == 6
     assert "ensembl:ENSG00000231995" not in [r["concept_id"] for r in results]
+
+    results = list(
+        get_term_mappings(test_db, scope=RecordType.MERGER, protein_coding_only=True)
+    )
+    assert len(results) == 2
+    assert "ncbigene:3378" not in [r["concept_id"] for r in results]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -151,6 +151,25 @@ def test_db(null_database_class):
                     "merge_ref": "hgnc:1097",
                     "item_type": "identity",
                 },
+                {
+                    "concept_id": "ensembl:ENSG00000231995",
+                    "label": "ribosomal protein L7a pseudogene 76",
+                    "strand": "+",
+                    "locations": [
+                        {
+                            "type": "SequenceLocation",
+                            "start": 62266318,
+                            "end": 62266919,
+                            "sequence_id": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+                        }
+                    ],
+                    "gene_type": "transcribed_processed_pseudogene",
+                    "symbol": "RPL7AP76",
+                    "xrefs": ["hgnc:55899"],
+                    "src_name": "Ensembl",
+                    "merge_ref": "hgnc:55899",
+                    "item_type": "identity",
+                },
             ],
             RecordType.MERGER: [
                 {
@@ -359,3 +378,11 @@ def test_get_term_mappings_merger(test_db: AbstractDatabase):
     ]
     diff = DeepDiff(fixture, results, ignore_order=True)
     assert diff == {}
+
+
+def test_get_term_mappings_protein_coding_only(test_db: AbstractDatabase):
+    results = list(
+        get_term_mappings(test_db, scope=RecordType.IDENTITY, protein_coding_only=True)
+    )
+    assert len(results) == 6
+    assert "ensembl:ENSG00000231995" not in [r["concept_id"] for r in results]


### PR DESCRIPTION
Around 50% of the gene records we have are probably never going to be used by varcat (lncRNA, etc) and may or may not end up polluting the autocomplete results a lot -- so I stubbed this out while I was thinking about it. We could be more hardcore about the specific types we select but I think this is pretty close to what we'd ultimately want.