### PR TITLE
fix: ensure backward compatibility w/ older assoc_with mappings

### DIFF
--- a/src/gene/query.py
+++ b/src/gene/query.py
@@ -457,11 +457,14 @@ class QueryHandler:
             if xref_id != record["concept_id"]
         ]
 
-        associated_with = record.get("associated_with", [])
-        gene_obj.mappings.extend(
-            _get_concept_mapping(associated_with_id, relation=Relation.RELATED_MATCH)
-            for associated_with_id in associated_with
-        )
+        for aw in record.get("associated_with", []):
+            try:
+                mapping = _get_concept_mapping(aw, relation=Relation.RELATED_MATCH)
+            except ValueError:
+                # catch and ignore to ensure compatibility with older DB releases
+                _logger.debug("Encountered invalid mapping: %s", aw)
+                continue
+            gene_obj.mappings.append(mapping)
 
         # extensions
         extensions = []


### PR DESCRIPTION
I feel like I have created and fixed this problem twice

Basically the prod/nonprod dynamo tables now have some `iuphar` xrefs that I think we shouldn't be letting through. However, at this point, I'm afraid to update the tables directly because of all the things that depend on them. And I also think that we should be handling this kind of problem better anyway. This PR logs any unrecognized xrefs and ignores them, rather than just crashing out completely.